### PR TITLE
Compress classic (one-line) logging to allow more space for the message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,14 +61,14 @@ configure(jvmProjects()) {
         springBootVersion = '3.2.4' // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/
         janinoVersion = '3.1.12'
         servletVersion = '6.0.0' // jakarta
-        logbookVersion = '3.7.2'
-        jacksonSyntaxHighlightVersion = '1.0.8'
+        logbookVersion = '3.8.0'
+        jacksonSyntaxHighlightVersion = '1.0.9'
         logbackLogstashSyntaxHighlightingDecoratorsVersion = '1.0.7'
-        commonsIoVersion = '2.15.1'
+        commonsIoVersion = '2.16.1'
         commonsTextVersion = '1.11.0'
 
-        grpcNettyVersion = '1.62.2'
-        grpcVersion = '1.62.2'
+        grpcNettyVersion = '1.63.0'
+        grpcVersion = '1.63.0'
         grpcCommonsVersion = '2.37.1'
         grpcProtobufVersion = '3.25.3'
 

--- a/gcp/spring-boot-autoconfigure-gcp-test/src/main/resources/logback/logback-spring-test.xml
+++ b/gcp/spring-boot-autoconfigure-gcp-test/src/main/resources/logback/logback-spring-test.xml
@@ -1,6 +1,7 @@
 <included>
+
 	<!-- from org/springframework/boot/logging/logback/base.xml -->
-	<include resource="org/springframework/boot/logging/logback/defaults.xml" />
+	<include resource="logback/spring-defaults-test.xml" />
 
 	<appender name="STDOUT" class="no.entur.logging.cloud.gcp.spring.test.SpringCompositeConsoleAppender">
 		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/gcp/spring-boot-autoconfigure-gcp-test/src/main/resources/logback/spring-defaults-test.xml
+++ b/gcp/spring-boot-autoconfigure-gcp-test/src/main/resources/logback/spring-defaults-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Default logback configuration provided for import by spring, modified to give message more room, excluding
+
+ - date and time zone
+ - pid
+ - application name
+-->
+
+<included>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(---){faint} %clr([%15.15t]){faint} %clr(${LOG_CORRELATION_PATTERN:-}){faint}%clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="CONSOLE_LOG_CHARSET" value="${CONSOLE_LOG_CHARSET:-${file.encoding:-UTF-8}}"/>
+    <property name="CONSOLE_LOG_THRESHOLD" value="${CONSOLE_LOG_THRESHOLD:-TRACE}"/>
+
+    <logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR"/>
+    <logger name="org.apache.catalina.util.LifecycleBase" level="ERROR"/>
+    <logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN"/>
+    <logger name="org.apache.sshd.common.util.SecurityUtils" level="WARN"/>
+    <logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN"/>
+    <logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="ERROR"/>
+    <logger name="org.hibernate.validator.internal.util.Version" level="WARN"/>
+    <logger name="org.springframework.boot.actuate.endpoint.jmx" level="WARN"/>
+</included>

--- a/gcp/spring-boot-autoconfigure-gcp/src/main/resources/logback-spring.xml
+++ b/gcp/spring-boot-autoconfigure-gcp/src/main/resources/logback-spring.xml
@@ -1,7 +1,6 @@
 <configuration>
 
     <!-- https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml -->
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="logback/logback-default-server.xml" />
 
     <!-- TODO refering to subproject properties is a bit ugly -->


### PR DESCRIPTION
+ bump dependencies