### PR TITLE
GCP trace MDC fields for gRPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ Desktop.ini
 .merge_file*
 /.gradle/
 /build/
+
+.profileconfig.json

--- a/examples/gcp-grpc-ecosystem-example/src/main/java/no/entur/grpc/example/GreetingController.java
+++ b/examples/gcp-grpc-ecosystem-example/src/main/java/no/entur/grpc/example/GreetingController.java
@@ -2,6 +2,7 @@ package no.entur.grpc.example;
 
 
 import net.devh.boot.grpc.server.service.GrpcService;
+import no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor.OrderedTraceIdGrpcMdcContextServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.OrderedGrpcLoggingServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.RequestResponseGrpcExceptionHandlerInterceptor;
 import no.entur.logging.cloud.trace.spring.grpc.interceptor.OrderedCorrelationIdGrpcMdcContextServerInterceptor;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Profile;
 @GrpcService(interceptors = {
 		// Trace
 		OrderedCorrelationIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
+		OrderedTraceIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
 
 		// logging
 		OrderedGrpcLoggingServerInterceptor.class,

--- a/examples/gcp-grpc-ecosystem-example/src/main/java/no/entur/grpc/example/GreetingControllerWithOnDemandLogging.java
+++ b/examples/gcp-grpc-ecosystem-example/src/main/java/no/entur/grpc/example/GreetingControllerWithOnDemandLogging.java
@@ -2,6 +2,7 @@ package no.entur.grpc.example;
 
 
 import net.devh.boot.grpc.server.service.GrpcService;
+import no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor.OrderedTraceIdGrpcMdcContextServerInterceptor;
 import no.entur.logging.cloud.spring.ondemand.grpc.scope.GrpcLoggingScopeContextInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.OrderedGrpcLoggingServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.RequestResponseGrpcExceptionHandlerInterceptor;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Profile;
 		GrpcLoggingScopeContextInterceptor.class,
 		// Trace
 		OrderedCorrelationIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
+		OrderedTraceIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
 
 		// logging
 		OrderedGrpcLoggingServerInterceptor.class,

--- a/examples/gcp-grpc-ecosystem-without-test-artifacts-example/src/main/java/no/entur/grpc/example/GreetingController.java
+++ b/examples/gcp-grpc-ecosystem-without-test-artifacts-example/src/main/java/no/entur/grpc/example/GreetingController.java
@@ -2,6 +2,7 @@ package no.entur.grpc.example;
 
 
 import net.devh.boot.grpc.server.service.GrpcService;
+import no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor.OrderedTraceIdGrpcMdcContextServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.OrderedGrpcLoggingServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.RequestResponseGrpcExceptionHandlerInterceptor;
 import no.entur.logging.cloud.trace.spring.grpc.interceptor.OrderedCorrelationIdGrpcMdcContextServerInterceptor;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Profile;
 @GrpcService(interceptors = {
 		// Trace
 		OrderedCorrelationIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
+		OrderedTraceIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
 
 		// logging
 		OrderedGrpcLoggingServerInterceptor.class,

--- a/examples/gcp-grpc-ecosystem-without-test-artifacts-example/src/main/java/no/entur/grpc/example/GreetingControllerWithOnDemandLogging.java
+++ b/examples/gcp-grpc-ecosystem-without-test-artifacts-example/src/main/java/no/entur/grpc/example/GreetingControllerWithOnDemandLogging.java
@@ -2,6 +2,7 @@ package no.entur.grpc.example;
 
 
 import net.devh.boot.grpc.server.service.GrpcService;
+import no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor.OrderedTraceIdGrpcMdcContextServerInterceptor;
 import no.entur.logging.cloud.spring.ondemand.grpc.scope.GrpcLoggingScopeContextInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.OrderedGrpcLoggingServerInterceptor;
 import no.entur.logging.cloud.spring.rr.grpc.RequestResponseGrpcExceptionHandlerInterceptor;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Profile;
 		GrpcLoggingScopeContextInterceptor.class,
 		// Trace
 		OrderedCorrelationIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
+		OrderedTraceIdGrpcMdcContextServerInterceptor.class, // add trace headers (correlation-id and such)
 
 		// logging
 		OrderedGrpcLoggingServerInterceptor.class,

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/README.md
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/README.md
@@ -1,0 +1,1 @@
+# GCP trace headers with legacy correlation-id tracing for GCP

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/README.md
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/README.md
@@ -1,1 +1,2 @@
 # GCP trace headers with legacy correlation-id tracing for GCP
+Adds `logging.googleapis.com/trace` and `logging.googleapis.com/spanId` to MDC context.

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/build.gradle
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/build.gradle
@@ -1,0 +1,16 @@
+
+dependencies {
+    api project(':trace:mdc-context-grpc-netty')
+    api project(':trace:server:correlation-id-trace-grpc-netty')
+    api project(':trace:server:correlation-id-trace-spring-boot-grpc')
+
+    api("org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}")
+
+    api "io.grpc:grpc-netty:${grpcNettyVersion}"
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}"
+}
+
+
+
+

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/GcpGrpcTraceAutoConfiguration.java
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/GcpGrpcTraceAutoConfiguration.java
@@ -1,0 +1,30 @@
+package no.entur.logging.cloud.gcp.trace.spring.grpc;
+
+import no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor.OrderedTraceIdGrpcMdcContextServerInterceptor;
+import no.entur.logging.cloud.trace.spring.grpc.GrpcCorrelationIdAutoConfiguration;
+import no.entur.logging.cloud.trace.spring.grpc.interceptor.OrderedCorrelationIdGrpcMdcContextServerInterceptor;
+import no.entur.logging.cloud.trace.spring.grpc.properties.GrpcMdcProperties;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigureAfter(GrpcCorrelationIdAutoConfiguration.class)
+public class GcpGrpcTraceAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingClass("io.opentelemetry.api.OpenTelemetry")
+    @ConditionalOnBean(OrderedCorrelationIdGrpcMdcContextServerInterceptor.class)
+    @ConditionalOnMissingBean(OrderedTraceIdGrpcMdcContextServerInterceptor.class)
+    public OrderedTraceIdGrpcMdcContextServerInterceptor orderedTraceIdGrpcMdcContextServerInterceptor(OrderedCorrelationIdGrpcMdcContextServerInterceptor interceptor) {
+        int order = interceptor.getOrder();
+
+        return new OrderedTraceIdGrpcMdcContextServerInterceptor(order + 1);
+    }
+
+}

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/GcpGrpcTraceAutoConfiguration.java
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/GcpGrpcTraceAutoConfiguration.java
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Configuration;
 public class GcpGrpcTraceAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingClass("io.opentelemetry.api.OpenTelemetry")
     @ConditionalOnBean(OrderedCorrelationIdGrpcMdcContextServerInterceptor.class)
     @ConditionalOnMissingBean(OrderedTraceIdGrpcMdcContextServerInterceptor.class)
     public OrderedTraceIdGrpcMdcContextServerInterceptor orderedTraceIdGrpcMdcContextServerInterceptor(OrderedCorrelationIdGrpcMdcContextServerInterceptor interceptor) {

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/interceptor/OrderedTraceIdGrpcMdcContextServerInterceptor.java
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/interceptor/OrderedTraceIdGrpcMdcContextServerInterceptor.java
@@ -1,0 +1,58 @@
+package no.entur.logging.cloud.gcp.trace.spring.grpc.interceptor;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import no.entur.logging.cloud.grpc.mdc.GrpcMdcContext;
+import no.entur.logging.cloud.grpc.trace.CorrelationIdGrpcMdcContext;
+import org.springframework.core.Ordered;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class OrderedTraceIdGrpcMdcContextServerInterceptor implements ServerInterceptor, Ordered {
+
+    // The span ID is expected to be a 16-character, hexadecimal encoding of an 8-byte array and should not be zero. It should be unique within the trace and should, ideally, be generated in a manner that is uniformly random.
+    public static final String SPAN_ID_MDC_KEY = "logging.googleapis.com/spanId";
+
+    // Note: If not writing to stdout or stderr, the value of this field should be formatted as projects/[PROJECT-ID]/traces/[TRACE-ID],
+    // so it can be used by the Logs Explorer and the Trace Viewer to group log entries and display them in line
+    // with traces.
+
+    public static final String TRACE_MDC_KEY = "logging.googleapis.com/trace";
+
+    private int order;
+
+    public OrderedTraceIdGrpcMdcContextServerInterceptor(int order) {
+        this.order = order;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        GrpcMdcContext grpcMdcContext = GrpcMdcContext.get();
+        if(grpcMdcContext == null) {
+            return next.startCall(call, headers);
+        }
+        String correlationId = grpcMdcContext.get(CorrelationIdGrpcMdcContext.CORRELATION_ID_MDC_KEY);
+
+        if(!grpcMdcContext.containsKey(TRACE_MDC_KEY)) {
+            grpcMdcContext.put(TRACE_MDC_KEY, correlationId);
+        }
+
+        if(!grpcMdcContext.containsKey(SPAN_ID_MDC_KEY)) {
+            //  16-character, hexadecimal encoding of an 8-byte array
+            ThreadLocalRandom current = ThreadLocalRandom.current();
+            long random = current.nextLong();
+            String spanId = Long.toHexString(random);
+            grpcMdcContext.put(SPAN_ID_MDC_KEY, spanId);
+        }
+
+        // no new context necessary
+        return next.startCall(call, headers);
+    }
+}

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/interceptor/OrderedTraceIdGrpcMdcContextServerInterceptor.java
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/java/no/entur/logging/cloud/gcp/trace/spring/grpc/interceptor/OrderedTraceIdGrpcMdcContextServerInterceptor.java
@@ -38,9 +38,11 @@ public class OrderedTraceIdGrpcMdcContextServerInterceptor implements ServerInte
         if(grpcMdcContext == null) {
             return next.startCall(call, headers);
         }
-        String correlationId = grpcMdcContext.get(CorrelationIdGrpcMdcContext.CORRELATION_ID_MDC_KEY);
 
+        // this interceptor runs after the CorrelationId interceptor, so there should always be a value here
         if(!grpcMdcContext.containsKey(TRACE_MDC_KEY)) {
+            String correlationId = grpcMdcContext.get(CorrelationIdGrpcMdcContext.CORRELATION_ID_MDC_KEY);
+
             grpcMdcContext.put(TRACE_MDC_KEY, correlationId);
         }
 

--- a/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gcp/correlation-id-trace-spring-boot-gcp-grpc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+no.entur.logging.cloud.gcp.trace.spring.grpc.GcpGrpcTraceAutoConfiguration

--- a/gcp/spring-boot-starter-gcp-grpc-ecosystem/build.gradle
+++ b/gcp/spring-boot-starter-gcp-grpc-ecosystem/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api project(':trace:mdc-context-grpc-netty')
     api project(':trace:server:correlation-id-trace-spring-boot-grpc')
     api project(':gcp:spring-boot-autoconfigure-gcp-grpc-mdc')
+    api project(':gcp:correlation-id-trace-spring-boot-gcp-grpc')
 
     api project(':gcp:micrometer-gcp')
     api project(':micrometer')

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include 'gcp:logback-logstash-encoder-gcp', 'gcp:spring-boot-autoconfigure-gcp',
 include 'gcp:spring-boot-starter-gcp-web', 'gcp:spring-boot-starter-gcp-web-test', 'gcp:spring-boot-starter-gcp-grpc-ecosystem-test', 'gcp:spring-boot-starter-gcp-grpc-ecosystem'
 include 'gcp:spring-boot-autoconfigure-gcp-test', 'gcp:request-response-spring-boot-starter-gcp-web', 'gcp:request-response-spring-boot-starter-gcp-web-test'
 include 'gcp:request-response-spring-boot-starter-gcp-grpc-ecosystem', 'gcp:request-response-spring-boot-starter-gcp-grpc-ecosystem-test'
+include 'gcp:correlation-id-trace-spring-boot-gcp-grpc'
 
 include 'gcp:micrometer-gcp'
 include 'gcp:logbook-spring-boot-autoconfigure-gcp'


### PR DESCRIPTION
Add MDC fields in new interceptor; use it opt-in.

Propagating headers downstream is up to the user for now.