### PR TITLE
Generate random correlationId when header value is string "null"

### DIFF
--- a/trace/server/correlation-id-trace-spring-boot-web/src/main/java/no/entur/logging/cloud/trace/spring/web/CorrelationIdFilter.java
+++ b/trace/server/correlation-id-trace-spring-boot-web/src/main/java/no/entur/logging/cloud/trace/spring/web/CorrelationIdFilter.java
@@ -60,7 +60,7 @@ public class CorrelationIdFilter implements Filter {
 			HttpServletRequest request = (HttpServletRequest) servletRequest;
 			String inputValue = request.getHeader(CORRELATION_ID_HTTP_HEADER);
 
-			if (inputValue == null) {
+			if (inputValue == null || inputValue.equals("null")) {
 				correlationId = UUID.randomUUID().toString();
 			} else {
 				correlationId = CorrelationIdMdcSupportBuilder.sanitize(inputValue);


### PR DESCRIPTION
Some clients fill the X-Correlation-Id header with this value, making the correlationId rig pretty useless deeper in the system. With this change we consider an X-Correlation-Id header with the value "null" in the same way as if it is not supplied at all.