### PR TITLE
ETU-65064: Adds support for log prefix

### DIFF
--- a/request-response/logbook-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/logbook/properties/MessageFormatProperties.java
+++ b/request-response/logbook-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/logbook/properties/MessageFormatProperties.java
@@ -4,6 +4,8 @@ import no.entur.logging.cloud.logbook.MessageComposer;
 
 public class MessageFormatProperties {
 
+    /** Custom prefix */
+    protected String prefix = null;
     /** Include URI protocol / scheme */
     protected boolean scheme = true;
     /** Include URI host */
@@ -14,6 +16,14 @@ public class MessageFormatProperties {
     protected boolean path = true;
     /** Include URI query */
     protected boolean query = true;
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
 
     public boolean isScheme() {
         return scheme;
@@ -56,6 +66,6 @@ public class MessageFormatProperties {
     }
 
     public MessageComposer toComposer() {
-        return new MessageComposer(scheme, host, port, path, query);
+        return new MessageComposer(prefix, scheme, host, port, path, query);
     }
 }

--- a/request-response/logbook/src/main/java/no/entur/logging/cloud/logbook/MessageComposer.java
+++ b/request-response/logbook/src/main/java/no/entur/logging/cloud/logbook/MessageComposer.java
@@ -16,13 +16,15 @@ import java.util.function.BooleanSupplier;
 
 public class MessageComposer {
 
+    protected String prefix;
     protected boolean scheme;
     protected boolean host;
     protected boolean port;
     protected boolean path;
     protected boolean query;
 
-    public MessageComposer(boolean scheme, boolean host, boolean port, boolean path, boolean query) {
+    public MessageComposer(String prefix, boolean scheme, boolean host, boolean port, boolean path, boolean query) {
+        this.prefix = prefix;
         this.scheme = scheme;
         this.host = host;
         this.port = port;
@@ -36,6 +38,9 @@ public class MessageComposer {
     }
 
     protected void constructMessage(HttpRequest request, StringBuilder messageBuilder) throws IOException {
+        if (prefix != null) {
+            messageBuilder.append(prefix);
+        }
         if (scheme) {
             String schemeValue = request.getScheme();
             if(schemeValue != null && !schemeValue.isEmpty()) {


### PR DESCRIPTION
Vi har et ønske om å kunne skille inngående med utgående kall i loggene.

Derfor trenger vi at log-konfigurasjonen støtter at man kan legge inn egendefinerte prefix for eksempel: [in] eller [out]