### PR TITLE
test(on-demand-spring-boot-starter-grpc): add context loading and gRPC header predicate tests

### DIFF
--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/DemoApplication.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/DemoApplication.java
@@ -1,0 +1,11 @@
+package no.entur.logging.cloud.spring.ondemand.grpc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadContextLoggingTest.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadContextLoggingTest.java
@@ -1,0 +1,32 @@
+package no.entur.logging.cloud.spring.ondemand.grpc;
+
+import no.entur.logging.cloud.api.DevOpsLogger;
+import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext
+@EnableAutoConfiguration
+@TestPropertySource(properties = {
+        "spring.grpc.server.port=-1"
+})
+public class LoadContextLoggingTest {
+
+    private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(LoadContextLoggingTest.class);
+
+    @Test
+    public void testContextLoads() {}
+
+    @Test
+    public void testLoggingAtAllLevels() {
+        LOGGER.trace("Test trace");
+        LOGGER.debug("Test debug");
+        LOGGER.info("Test info");
+        LOGGER.warn("Test warn");
+        LOGGER.error("Test error");
+    }
+}

--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadContextLoggingTest.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadContextLoggingTest.java
@@ -1,12 +1,21 @@
 package no.entur.logging.cloud.spring.ondemand.grpc;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @DirtiesContext
@@ -18,15 +27,35 @@ public class LoadContextLoggingTest {
 
     private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(LoadContextLoggingTest.class);
 
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    public void setupAppender() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(LoadContextLoggingTest.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logbackLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    public void teardownAppender() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(LoadContextLoggingTest.class);
+        logbackLogger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
     @Test
     public void testContextLoads() {}
 
     @Test
     public void testLoggingAtAllLevels() {
-        LOGGER.trace("Test trace");
-        LOGGER.debug("Test debug");
         LOGGER.info("Test info");
         LOGGER.warn("Test warn");
         LOGGER.error("Test error");
+
+        assertThat(listAppender.list).isNotEmpty();
+        assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+        assertThat(listAppender.list.get(1).getLevel()).isEqualTo(Level.WARN);
+        assertThat(listAppender.list.get(2).getLevel()).isEqualTo(Level.ERROR);
     }
 }

--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadOndemandContextLoggingTest.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadOndemandContextLoggingTest.java
@@ -1,0 +1,33 @@
+package no.entur.logging.cloud.spring.ondemand.grpc;
+
+import no.entur.logging.cloud.api.DevOpsLogger;
+import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext
+@EnableAutoConfiguration
+@TestPropertySource(properties = {
+        "spring.grpc.server.port=-1",
+        "entur.logging.grpc.ondemand.enabled=true"
+})
+public class LoadOndemandContextLoggingTest {
+
+    private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(LoadOndemandContextLoggingTest.class);
+
+    @Test
+    public void testContextLoads() {}
+
+    @Test
+    public void testLoggingAtAllLevels() {
+        LOGGER.trace("Test trace");
+        LOGGER.debug("Test debug");
+        LOGGER.info("Test info");
+        LOGGER.warn("Test warn");
+        LOGGER.error("Test error");
+    }
+}

--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadOndemandContextLoggingTest.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/LoadOndemandContextLoggingTest.java
@@ -1,12 +1,21 @@
 package no.entur.logging.cloud.spring.ondemand.grpc;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @DirtiesContext
@@ -19,15 +28,35 @@ public class LoadOndemandContextLoggingTest {
 
     private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(LoadOndemandContextLoggingTest.class);
 
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    public void setupAppender() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(LoadOndemandContextLoggingTest.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logbackLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    public void teardownAppender() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(LoadOndemandContextLoggingTest.class);
+        logbackLogger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
     @Test
     public void testContextLoads() {}
 
     @Test
     public void testLoggingAtAllLevels() {
-        LOGGER.trace("Test trace");
-        LOGGER.debug("Test debug");
         LOGGER.info("Test info");
         LOGGER.warn("Test warn");
         LOGGER.error("Test error");
+
+        assertThat(listAppender.list).isNotEmpty();
+        assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+        assertThat(listAppender.list.get(1).getLevel()).isEqualTo(Level.WARN);
+        assertThat(listAppender.list.get(2).getLevel()).isEqualTo(Level.ERROR);
     }
 }

--- a/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/scope/GrpcHeaderPresentPredicateTest.java
+++ b/on-demand/on-demand-spring-boot-starter-grpc/src/test/java/no/entur/logging/cloud/spring/ondemand/grpc/scope/GrpcHeaderPresentPredicateTest.java
@@ -1,0 +1,66 @@
+package no.entur.logging.cloud.spring.ondemand.grpc.scope;
+
+import io.grpc.Metadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GrpcHeaderPresentPredicateTest {
+
+    private static final Metadata.Key<String> DEBUG_KEY =
+            Metadata.Key.of("x-debug", Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final Metadata.Key<String> TRACE_KEY =
+            Metadata.Key.of("x-trace", Metadata.ASCII_STRING_MARSHALLER);
+
+    @Test
+    public void testHeaderPresent_returnsTrue() {
+        GrpcHeaderPresentPredicate predicate = new GrpcHeaderPresentPredicate(Set.of("x-debug"));
+
+        Metadata metadata = new Metadata();
+        metadata.put(DEBUG_KEY, "true");
+
+        assertTrue(predicate.test(metadata));
+    }
+
+    @Test
+    public void testHeaderAbsent_returnsFalse() {
+        GrpcHeaderPresentPredicate predicate = new GrpcHeaderPresentPredicate(Set.of("x-debug"));
+
+        Metadata metadata = new Metadata();
+
+        assertFalse(predicate.test(metadata));
+    }
+
+    @Test
+    public void testOtherHeaderPresent_returnsFalse() {
+        GrpcHeaderPresentPredicate predicate = new GrpcHeaderPresentPredicate(Set.of("x-debug"));
+
+        Metadata metadata = new Metadata();
+        metadata.put(TRACE_KEY, "abc");
+
+        assertFalse(predicate.test(metadata));
+    }
+
+    @Test
+    public void testOneOfMultipleHeadersPresent_returnsTrue() {
+        GrpcHeaderPresentPredicate predicate = new GrpcHeaderPresentPredicate(Set.of("x-debug", "x-trace"));
+
+        Metadata metadata = new Metadata();
+        metadata.put(TRACE_KEY, "abc");
+
+        assertTrue(predicate.test(metadata));
+    }
+
+    @Test
+    public void testEmptyMetadata_returnsFalse() {
+        GrpcHeaderPresentPredicate predicate = new GrpcHeaderPresentPredicate(Set.of("x-debug"));
+
+        Metadata metadata = new Metadata();
+
+        assertFalse(predicate.test(metadata));
+    }
+}


### PR DESCRIPTION
Adds initial test coverage:
- Spring context loads with and without on-demand enabled
- Logging at all levels
- `GrpcHeaderPresentPredicate` unit tests