### PR TITLE
test(spring-boot-starter-gcp-web): add MDC and log event format tests

### DIFF
--- a/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/LoggingOutputFormatTest.java
+++ b/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/LoggingOutputFormatTest.java
@@ -1,0 +1,108 @@
+package no.entur.logging.cloud.gcp.spring.web;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import no.entur.logging.cloud.api.DevOpsLevel;
+import no.entur.logging.cloud.api.DevOpsLogger;
+import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import no.entur.logging.cloud.api.DevOpsMarker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext
+@EnableAutoConfiguration
+public class LoggingOutputFormatTest {
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
+    private DevOpsLogger devOpsLogger;
+
+    @BeforeEach
+    public void setUp() {
+        logger = (Logger) LoggerFactory.getLogger("test.format");
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+        devOpsLogger = DevOpsLoggerFactory.getLogger(logger);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+        MDC.clear();
+    }
+
+    @Test
+    public void testInfoEventHasCorrectLevel() {
+        logger.info("test info message");
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+    }
+
+    @Test
+    public void testErrorEventHasCorrectLevel() {
+        logger.error("test error message");
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    public void testWarnEventHasCorrectLevel() {
+        logger.warn("test warn message");
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+    }
+
+    @Test
+    public void testExceptionIncludedInEvent() {
+        RuntimeException exception = new RuntimeException("something went wrong");
+        logger.error("test error with exception", exception);
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getThrowableProxy()).isNotNull();
+        assertThat(listAppender.list.get(0).getThrowableProxy().getMessage()).isEqualTo("something went wrong");
+    }
+
+    @Test
+    public void testMdcValueCapturedInEvent() {
+        MDC.put("correlationId", "abc-456");
+        logger.info("test mdc message");
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getMDCPropertyMap()).containsKey("correlationId");
+        assertThat(listAppender.list.get(0).getMDCPropertyMap().get("correlationId")).isEqualTo("abc-456");
+    }
+
+    @Test
+    public void testDevOpsMarkerPresent() {
+        devOpsLogger.errorTellMeTomorrow("test devops marker message");
+
+        assertThat(listAppender.list).hasSize(1);
+        ILoggingEvent event = listAppender.list.get(0);
+        List<Marker> markers = event.getMarkerList();
+        assertThat(markers).isNotNull();
+        assertThat(markers).isNotEmpty();
+        Marker firstMarker = markers.get(0);
+        assertThat(firstMarker).isInstanceOf(DevOpsMarker.class);
+        DevOpsMarker devOpsMarker = (DevOpsMarker) firstMarker;
+        assertThat(devOpsMarker.getDevOpsLevel()).isEqualTo(DevOpsLevel.ERROR_TELL_ME_TOMORROW);
+    }
+}

--- a/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/MdcLoggingTest.java
+++ b/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/MdcLoggingTest.java
@@ -1,0 +1,29 @@
+package no.entur.logging.cloud.gcp.spring.web;
+
+import no.entur.logging.cloud.api.DevOpsLogger;
+import no.entur.logging.cloud.api.DevOpsLoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext
+@EnableAutoConfiguration
+public class MdcLoggingTest {
+
+    private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(MdcLoggingTest.class);
+
+    @AfterEach
+    public void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    public void testMdcValueIncludedInLog() {
+        MDC.put("correlationId", "test-123");
+        LOGGER.info("Test info message with MDC correlationId");
+    }
+}

--- a/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/MdcLoggingTest.java
+++ b/gcp/spring-boot-starter-gcp-web/src/test/java/no/entur/logging/cloud/gcp/spring/web/MdcLoggingTest.java
@@ -1,13 +1,20 @@
 package no.entur.logging.cloud.gcp.spring.web;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @DirtiesContext
@@ -16,8 +23,21 @@ public class MdcLoggingTest {
 
     private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(MdcLoggingTest.class);
 
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    public void setupAppender() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(MdcLoggingTest.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logbackLogger.addAppender(listAppender);
+    }
+
     @AfterEach
-    public void clearMdc() {
+    public void teardown() {
+        Logger logbackLogger = (Logger) LoggerFactory.getLogger(MdcLoggingTest.class);
+        logbackLogger.detachAppender(listAppender);
+        listAppender.stop();
         MDC.clear();
     }
 
@@ -25,5 +45,9 @@ public class MdcLoggingTest {
     public void testMdcValueIncludedInLog() {
         MDC.put("correlationId", "test-123");
         LOGGER.info("Test info message with MDC correlationId");
+
+        assertThat(listAppender.list).hasSize(1);
+        assertThat(listAppender.list.get(0).getMDCPropertyMap()).containsKey("correlationId");
+        assertThat(listAppender.list.get(0).getMDCPropertyMap().get("correlationId")).isEqualTo("test-123");
     }
 }


### PR DESCRIPTION
Adds tests that verify:
- MDC values are captured in log events
- Log level is correctly set on captured events
- Exception proxy is populated when logging with exception
- DevOpsMarker is present on DevOpsLogger error variants