### PR TITLE
test(logback-logstash-encoder-gcp): add unit tests for severity, MDC and service context providers

### DIFF
--- a/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/SimpleMdcJsonProviderTest.java
+++ b/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/SimpleMdcJsonProviderTest.java
@@ -1,0 +1,84 @@
+package no.entur.logging.cloud.gcp.logback.logstash;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class SimpleMdcJsonProviderTest {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void writeTo_mdcEntries_writtenAsTopLevelStringFields() throws Exception {
+        Map<String, String> mdc = new LinkedHashMap<>();
+        mdc.put("traceId", "abc123");
+        mdc.put("spanId", "def456");
+
+        JsonNode root = write(mdc);
+
+        assertThat(root.get("traceId").asText()).isEqualTo("abc123");
+        assertThat(root.get("spanId").asText()).isEqualTo("def456");
+    }
+
+    @Test
+    void writeTo_nullKey_isSkipped() throws Exception {
+        Map<String, String> mdc = new LinkedHashMap<>();
+        mdc.put(null, "someValue");
+        mdc.put("key", "value");
+
+        JsonNode root = write(mdc);
+
+        assertThat(root.get("key").asText()).isEqualTo("value");
+        assertThat(root.size()).isEqualTo(1);
+    }
+
+    @Test
+    void writeTo_nullValue_isSkipped() throws Exception {
+        Map<String, String> mdc = new LinkedHashMap<>();
+        mdc.put("nullVal", null);
+        mdc.put("key", "value");
+
+        JsonNode root = write(mdc);
+
+        assertThat(root.has("nullVal")).isFalse();
+        assertThat(root.get("key").asText()).isEqualTo("value");
+    }
+
+    @Test
+    void writeTo_emptyMdcMap_writesNoFields() throws Exception {
+        JsonNode root = write(Collections.emptyMap());
+        assertThat(root.size()).isEqualTo(0);
+    }
+
+    @Test
+    void writeTo_nullMdcMap_writesNoFields() throws Exception {
+        JsonNode root = write(null);
+        assertThat(root.size()).isEqualTo(0);
+    }
+
+    private static JsonNode write(Map<String, String> mdcMap) throws Exception {
+        SimpleMdcJsonProvider provider = new SimpleMdcJsonProvider();
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(mdcMap);
+
+        StringWriter stringWriter = new StringWriter();
+        JsonFactory factory = new JsonFactory();
+        try (JsonGenerator generator = factory.createGenerator(stringWriter)) {
+            generator.writeStartObject();
+            provider.writeTo(generator, event);
+            generator.writeEndObject();
+        }
+        return MAPPER.readTree(stringWriter.toString());
+    }
+}

--- a/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverLogSeverityJsonProviderTest.java
+++ b/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverLogSeverityJsonProviderTest.java
@@ -1,0 +1,111 @@
+package no.entur.logging.cloud.gcp.logback.logstash;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import no.entur.logging.cloud.api.DevOpsMarker;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.StringWriter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class StackdriverLogSeverityJsonProviderTest {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void getSeverity_trace_mapsToDebug() {
+        ILoggingEvent event = mockEventWithLevel(Level.TRACE);
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.DEBUG);
+    }
+
+    @Test
+    void getSeverity_debug_mapsToDebug() {
+        ILoggingEvent event = mockEventWithLevel(Level.DEBUG);
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.DEBUG);
+    }
+
+    @Test
+    void getSeverity_info_mapsToInfo() {
+        ILoggingEvent event = mockEventWithLevel(Level.INFO);
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.INFO);
+    }
+
+    @Test
+    void getSeverity_warn_mapsToWarning() {
+        ILoggingEvent event = mockEventWithLevel(Level.WARN);
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.WARNING);
+    }
+
+    @Test
+    void getSeverity_errorWithoutMarker_mapsToError() {
+        ILoggingEvent event = mockEventWithLevel(Level.ERROR);
+        Mockito.when(event.getMarker()).thenReturn(null);
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.ERROR);
+    }
+
+    @Test
+    void getSeverity_errorWithTellMeTomorrowMarker_mapsToError() {
+        ILoggingEvent event = mockEventWithLevel(Level.ERROR);
+        Mockito.when(event.getMarker()).thenReturn(DevOpsMarker.errorTellMeTomorrow());
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.ERROR);
+    }
+
+    @Test
+    void getSeverity_errorWithInterruptMyDinnerMarker_mapsToCritical() {
+        ILoggingEvent event = mockEventWithLevel(Level.ERROR);
+        Mockito.when(event.getMarker()).thenReturn(DevOpsMarker.errorInterruptMyDinner());
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.CRITICAL);
+    }
+
+    @Test
+    void getSeverity_errorWithWakeMeUpRightNowMarker_mapsToAlert() {
+        ILoggingEvent event = mockEventWithLevel(Level.ERROR);
+        Mockito.when(event.getMarker()).thenReturn(DevOpsMarker.errorWakeMeUpRightNow());
+        assertThat(StackdriverLogSeverityJsonProvider.getSeverity(event)).isEqualTo(StackdriverSeverity.ALERT);
+    }
+
+    @Test
+    void writeTo_infoEvent_writesSeverityFieldWithCorrectValue() throws Exception {
+        StackdriverLogSeverityJsonProvider provider = new StackdriverLogSeverityJsonProvider();
+        ILoggingEvent event = mockEventWithLevel(Level.INFO);
+
+        JsonNode root = write(provider, event);
+
+        assertThat(root.has("severity")).isTrue();
+        assertThat(root.get("severity").asText()).isEqualTo("INFO");
+    }
+
+    @Test
+    void writeTo_usesFieldNameSeverityNotLevel() throws Exception {
+        StackdriverLogSeverityJsonProvider provider = new StackdriverLogSeverityJsonProvider();
+        ILoggingEvent event = mockEventWithLevel(Level.WARN);
+
+        JsonNode root = write(provider, event);
+
+        assertThat(root.has("severity")).isTrue();
+        assertThat(root.has("level")).isFalse();
+    }
+
+    private static ILoggingEvent mockEventWithLevel(Level level) {
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getLevel()).thenReturn(level);
+        return event;
+    }
+
+    private static JsonNode write(StackdriverLogSeverityJsonProvider provider, ILoggingEvent event) throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        JsonFactory factory = new JsonFactory();
+        try (JsonGenerator generator = factory.createGenerator(stringWriter)) {
+            generator.writeStartObject();
+            provider.writeTo(generator, event);
+            generator.writeEndObject();
+        }
+        return MAPPER.readTree(stringWriter.toString());
+    }
+}

--- a/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverServiceContextJsonProviderTest.java
+++ b/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverServiceContextJsonProviderTest.java
@@ -1,0 +1,111 @@
+package no.entur.logging.cloud.gcp.logback.logstash;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.StringWriter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class StackdriverServiceContextJsonProviderTest {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    // --- parseServiceNameFromHostname ---
+
+    @Test
+    void parseServiceNameFromHostname_typicalKubernetesHost_stripsLastTwoSegments() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname("my-service-abc123-5"))
+                .isEqualTo("my-service");
+    }
+
+    @Test
+    void parseServiceNameFromHostname_threeSegments_returnsFirstSegment() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname("a-b-c"))
+                .isEqualTo("a");
+    }
+
+    @Test
+    void parseServiceNameFromHostname_null_returnsNull() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname(null)).isNull();
+    }
+
+    @Test
+    void parseServiceNameFromHostname_emptyString_returnsNull() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname("")).isNull();
+    }
+
+    @Test
+    void parseServiceNameFromHostname_noHyphens_returnsNull() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname("noHyphens")).isNull();
+    }
+
+    @Test
+    void parseServiceNameFromHostname_oneHyphen_returnsNull() {
+        assertThat(StackdriverServiceContextJsonProvider.parseServiceNameFromHostname("one-hyphen")).isNull();
+    }
+
+    // --- writeTo ---
+
+    @Test
+    void writeTo_withServiceSet_writesServiceContextObject() throws Exception {
+        StackdriverServiceContextJsonProvider provider = new StackdriverServiceContextJsonProvider();
+        provider.setService("my-app");
+
+        JsonNode root = write(provider);
+
+        assertThat(root.has("serviceContext")).isTrue();
+        assertThat(root.get("serviceContext").get("service").asText()).isEqualTo("my-app");
+    }
+
+    @Test
+    void writeTo_withNullService_writesNothing() throws Exception {
+        StackdriverServiceContextJsonProvider provider = new StackdriverServiceContextJsonProvider();
+        // service is null by default; no env var set in test environment
+
+        JsonNode root = write(provider);
+
+        assertThat(root.has("serviceContext")).isFalse();
+        assertThat(root.size()).isEqualTo(0);
+    }
+
+    @Test
+    void writeTo_withServiceAndVersion_writesBothFields() throws Exception {
+        StackdriverServiceContextJsonProvider provider = new StackdriverServiceContextJsonProvider();
+        provider.setService("my-app");
+        provider.setVersion("1.2.3");
+
+        JsonNode root = write(provider);
+
+        assertThat(root.get("serviceContext").get("service").asText()).isEqualTo("my-app");
+        assertThat(root.get("serviceContext").get("version").asText()).isEqualTo("1.2.3");
+    }
+
+    @Test
+    void writeTo_withServiceAndNullVersion_omitsVersionField() throws Exception {
+        StackdriverServiceContextJsonProvider provider = new StackdriverServiceContextJsonProvider();
+        provider.setService("my-app");
+        provider.setVersion(null);
+
+        JsonNode root = write(provider);
+
+        assertThat(root.get("serviceContext").has("version")).isFalse();
+    }
+
+    private static JsonNode write(StackdriverServiceContextJsonProvider provider) throws Exception {
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        StringWriter stringWriter = new StringWriter();
+        JsonFactory factory = new JsonFactory();
+        try (JsonGenerator generator = factory.createGenerator(stringWriter)) {
+            generator.writeStartObject();
+            provider.writeTo(generator, event);
+            generator.writeEndObject();
+        }
+        return MAPPER.readTree(stringWriter.toString());
+    }
+}

--- a/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverSeverityTest.java
+++ b/gcp/logback-logstash-encoder-gcp/src/test/java/no/entur/logging/cloud/gcp/logback/logstash/StackdriverSeverityTest.java
@@ -1,0 +1,42 @@
+package no.entur.logging.cloud.gcp.logback.logstash;
+
+import no.entur.logging.cloud.api.DevOpsLevel;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class StackdriverSeverityTest {
+
+    @Test
+    void forDevOpsLevel_errorTellMeTomorrow_mapsToError() {
+        assertThat(StackdriverSeverity.forDevOpsLevel(DevOpsLevel.ERROR_TELL_ME_TOMORROW))
+                .isEqualTo(StackdriverSeverity.ERROR);
+    }
+
+    @Test
+    void forDevOpsLevel_errorInterruptMyDinner_mapsToCritical() {
+        assertThat(StackdriverSeverity.forDevOpsLevel(DevOpsLevel.ERROR_INTERRUPT_MY_DINNER))
+                .isEqualTo(StackdriverSeverity.CRITICAL);
+    }
+
+    @Test
+    void forDevOpsLevel_errorWakeMeUpRightNow_mapsToAlert() {
+        assertThat(StackdriverSeverity.forDevOpsLevel(DevOpsLevel.ERROR_WAKE_ME_UP_RIGHT_NOW))
+                .isEqualTo(StackdriverSeverity.ALERT);
+    }
+
+    @Test
+    void isGreaterOrEqual_errorGreaterThanWarning_isTrue() {
+        assertThat(StackdriverSeverity.ERROR.isGreaterOrEqual(StackdriverSeverity.WARNING)).isTrue();
+    }
+
+    @Test
+    void isGreaterOrEqual_infoEqualToInfo_isTrue() {
+        assertThat(StackdriverSeverity.INFO.isGreaterOrEqual(StackdriverSeverity.INFO)).isTrue();
+    }
+
+    @Test
+    void isGreaterOrEqual_debugLessThanWarning_isFalse() {
+        assertThat(StackdriverSeverity.DEBUG.isGreaterOrEqual(StackdriverSeverity.WARNING)).isFalse();
+    }
+}


### PR DESCRIPTION
Adds unit tests for:
- `StackdriverSeverity` enum (forDevOpsLevel, isGreaterOrEqual)
- `StackdriverLogSeverityJsonProvider` (level→severity mapping, writeTo)
- `SimpleMdcJsonProvider` (MDC field output, null handling)
- `StackdriverServiceContextJsonProvider` (hostname parsing, JSON output)