### PR TITLE
Increase request-response max log statement size for GCP

### DIFF
--- a/gcp/logbook-spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/spring/logbook/gcp/LogbookGcpAutoConfiguration.java
+++ b/gcp/logbook-spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/spring/logbook/gcp/LogbookGcpAutoConfiguration.java
@@ -15,7 +15,7 @@ public class LogbookGcpAutoConfiguration {
         LogbookLoggingCloudProperties c = new LogbookLoggingCloudProperties();
         // hard limit as of April 2026: 256 KiB - where KiB is 1024 bytes
         // Body: set it to 224 KiB to be on the safe side,
-        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, etc.
+        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, bytes vs chars, etc.
         c.setMaxBodySize(229376);
         c.setMaxSize(262144 - 2 * 1024); // inaccurate + currently not enforced
         return c;

--- a/gcp/logbook-spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/spring/logbook/gcp/LogbookGcpAutoConfiguration.java
+++ b/gcp/logbook-spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/spring/logbook/gcp/LogbookGcpAutoConfiguration.java
@@ -13,9 +13,11 @@ public class LogbookGcpAutoConfiguration {
     @Bean
     public LogbookLoggingCloudProperties logbookCloudConfiguration() {
         LogbookLoggingCloudProperties c = new LogbookLoggingCloudProperties();
-        // subtract a few kb for headers and other wrapping
-        c.setMaxBodySize(131072 - 2 * 1024);
-        c.setMaxSize(131072);
+        // hard limit as of April 2026: 256 KiB - where KiB is 1024 bytes
+        // Body: set it to 224 KiB to be on the safe side,
+        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, etc.
+        c.setMaxBodySize(229376);
+        c.setMaxSize(262144 - 2 * 1024); // inaccurate + currently not enforced
         return c;
     }
 }

--- a/gcp/request-response-spring-boot-starter-gcp-grpc-spring/src/main/java/no/entur/logging/cloud/gcp/spring/gcp/grpc/spring/RequestResponseGcpGrpcSpringAutoConfiguration.java
+++ b/gcp/request-response-spring-boot-starter-gcp-grpc-spring/src/main/java/no/entur/logging/cloud/gcp/spring/gcp/grpc/spring/RequestResponseGcpGrpcSpringAutoConfiguration.java
@@ -15,7 +15,7 @@ public class RequestResponseGcpGrpcSpringAutoConfiguration {
         GrpcLoggingCloudProperties c = new GrpcLoggingCloudProperties();
         // hard limit as of April 2026: 256 KiB - where KiB is 1024 bytes
         // Body: set it to 224 KiB to be on the safe side,
-        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, etc.
+        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, bytes vs chars, etc.
         c.setMaxBodySize(229376);
         c.setMaxSize(262144 - 2 * 1024); // inaccurate + currently not enforced
         return c;

--- a/gcp/request-response-spring-boot-starter-gcp-grpc-spring/src/main/java/no/entur/logging/cloud/gcp/spring/gcp/grpc/spring/RequestResponseGcpGrpcSpringAutoConfiguration.java
+++ b/gcp/request-response-spring-boot-starter-gcp-grpc-spring/src/main/java/no/entur/logging/cloud/gcp/spring/gcp/grpc/spring/RequestResponseGcpGrpcSpringAutoConfiguration.java
@@ -13,9 +13,11 @@ public class RequestResponseGcpGrpcSpringAutoConfiguration {
     @Bean
     public GrpcLoggingCloudProperties grpcLoggingCloudProperties() {
         GrpcLoggingCloudProperties c = new GrpcLoggingCloudProperties();
-        // subtract a few kb for headers and other wrapping
-        c.setMaxBodySize(131072 - 2 * 1024);
-        c.setMaxSize(131072);
+        // hard limit as of April 2026: 256 KiB - where KiB is 1024 bytes
+        // Body: set it to 224 KiB to be on the safe side,
+        // and to allow for a lot of overhead in the logging framework, MDC, HTTP headers, etc.
+        c.setMaxBodySize(229376);
+        c.setMaxSize(262144 - 2 * 1024); // inaccurate + currently not enforced
         return c;
     }
 }

--- a/guides/gRPC.md
+++ b/guides/gRPC.md
@@ -163,6 +163,15 @@ testImplementation ("no.entur.logging.cloud:request-response-spring-boot-starter
 ```
 </details>
 
+Please note:
+
+ * GCP `LogEntry` has a hard size limit of 256 KiB. Request/response bodies are truncated at 224 KiB by default to stay safely within this limit, accounting for headers, MDC fields, and other log-framework overhead. Override the default using:
+    ```
+    entur.logging.request-response.max-body-size=<bytes>
+    entur.logging.request-response.max-size=<bytes>
+    ```
+    See also: [Too long lines](troubleShooting.md#too-long-lines).
+
 Adjust the logger using
 
 ```

--- a/guides/troubleShooting.md
+++ b/guides/troubleShooting.md
@@ -136,4 +136,4 @@ Does not always translate into `textPayload`.
 
 > Failed to process request with tag kube_abt-xxx_abt-ccc-79d5974b67-jdsk8_abt-ccc_stdout: rpc error: code = InvalidArgument desc = Log entry with size 278.8K exceeds maximum size of 256.0K
 
-Resolution: Truncate long values.
+Resolution: Truncate long values. For request-response logging, the library automatically truncates request/response bodies at 224 KiB by default (GCP `LogEntry` max is 256 KiB). The limit can be lowered further via `entur.logging.request-response.max-body-size`.

--- a/guides/web.md
+++ b/guides/web.md
@@ -130,6 +130,12 @@ Please note:
  * For request-response-logging, this library assumes that locally produced JSON has valid syntax and is without pretty-printing. 
     * This assumption is made so to avoid the processing overhead of unnecessarily parsing JSON documents known to be valid.
     * If this assumption for some reason does not hold, use a BodyFilter to compensate.
+ * GCP `LogEntry` has a hard size limit of 256 KiB. Request/response bodies are truncated at 224 KiB by default to stay safely within this limit, accounting for headers, MDC fields, and other log-framework overhead. Override the default using:
+    ```
+    entur.logging.request-response.max-body-size=<bytes>
+    entur.logging.request-response.max-size=<bytes>
+    ```
+    See also: [Too long lines](troubleShooting.md#too-long-lines).
 
 Some Logbook excludes ([actuator, openapi](https://github.com/entur/cloud-logging/blob/main/request-response/logbook-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/logbook/LogbookLoggingAutoConfiguration.java)) are included by default. Add more using
 


### PR DESCRIPTION
Max size increased from about 130k to 230k for body. 

`LogEntry` [max is 256k,](https://docs.cloud.google.com/logging/quotas) but that includes various wrapping. 

A quick smoke-tests found that wrapping was about 2k, so 230k should be very much on the safe size. 

TODO: legacy branch