### PR TITLE
Disable gradle module file publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,3 +325,8 @@ jreleaser {
         }
     }
 }
+
+// Disable generation of Gradle module metadata to avoid leaking spring dependencies where we don't want them
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}


### PR DESCRIPTION
Users report dependabot unexpectedly triggers on artifacts from Spring dependency management.

We are importing

```
api(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
``` 

While the pom.xml files look good (from [appender](https://repo1.maven.org/maven2/no/entur/logging/cloud/appender/6.1.0/appender-6.1.0.module))

```
<dependencies>
  <dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-api</artifactId>
    <scope>compile</scope>
    <version>2.0.17</version>
  </dependency>
  <dependency>
    <groupId>ch.qos.logback</groupId>
    <artifactId>logback-classic</artifactId>
    <scope>compile</scope>
    <version>1.5.32</version>
  </dependency>
  <dependency>
    <groupId>ch.qos.logback</groupId>
    <artifactId>logback-core</artifactId>
    <scope>compile</scope>
    <version>1.5.32</version>
  </dependency>
</dependencies>
```


the gradle module files contains `spring-boot-dependencies`:
```
      "dependencies": [
        {
          "group": "org.springframework.boot",
          "module": "spring-boot-dependencies",
          "version": {
            "requires": "4.0.6"
          },
          "attributes": {
            "org.gradle.category": "platform"
          },
          "endorseStrictVersions": true
        },
        {
          "group": "org.slf4j",
          "module": "slf4j-api"
        },
        {
          "group": "ch.qos.logback",
          "module": "logback-classic"
        },
        {
          "group": "ch.qos.logback",
          "module": "logback-core"
        }
      ],
```

To my knowledge we do not use any feature which would require use of module files, so disable them for now. Possibly revisit this and use the spring boot dependency plugin. 
