### PR TITLE
Bump tomcat version 11 due to security issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,17 @@ configure(jvmProjects()) {
             isNonStable(it.candidate.version)
         }
     }
+
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'org.apache.tomcat.embed') {
+                if (isLowerThanMin(details.requested.version, "11.0.22")) {
+                    details.useVersion '11.0.22'
+                    details.because 'Security issues'
+                }
+            }
+        }
+    }
 }
 
 ext.stagingRepositoryPath = "${rootDir.getCanonicalFile()}/build/staging-deploy"
@@ -334,3 +345,7 @@ jreleaser {
     }
 }
 
+boolean isLowerThanMin(String currentVersion, String minVersion) {
+    if (currentVersion == null || minVersion == null) return false
+    return new org.apache.maven.artifact.versioning.ComparableVersion(currentVersion) < new org.apache.maven.artifact.versioning.ComparableVersion(minVersion)
+}


### PR DESCRIPTION


Dependencies tree from example:

```
|    +--- org.apache.tomcat.embed:tomcat-embed-core:11.0.21 -> 11.0.22 (c)
|    +--- org.apache.tomcat.embed:tomcat-embed-el:11.0.21 -> 11.0.22 (c)
|    +--- org.apache.tomcat.embed:tomcat-embed-websocket:11.0.21 -> 11.0.22 (c)
```