### PR TITLE
Prepare metrics counters for Spring Boot 4.1 / Micrometer 1.17 compatibility

### DIFF
--- a/azure/micrometer-azure/src/main/java/no/entur/logging/cloud/azure/micrometer/AzureMetricsTurboFilter.java
+++ b/azure/micrometer-azure/src/main/java/no/entur/logging/cloud/azure/micrometer/AzureMetricsTurboFilter.java
@@ -5,72 +5,60 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import no.entur.logging.cloud.api.DevOpsLevel;
 import no.entur.logging.cloud.api.DevOpsMarker;
-import org.slf4j.Marker;
+import no.entur.logging.cloud.micrometer.counter.EventCounter;
+import no.entur.logging.cloud.micrometer.counter.EventCounterFactory;
 import no.entur.logging.cloud.micrometer.LoggingEventMetrics;
+import org.slf4j.Marker;
 
 import java.util.List;
 
 
 public class AzureMetricsTurboFilter extends TurboFilter implements LoggingEventMetrics {
 
-    private final Counter alertCounter;
-    private final Counter criticalCounter;
-    private final Counter errorCounter;
-    private final Counter warnCounter;
-    private final Counter infoCounter;
-    private final Counter debugCounter;
-    private final Counter defaultCounter;
+    private static final EventCounterFactory COUNTER_FACTORY = EventCounterFactory.forCurrentMicrometerVersion();
+
+    private final EventCounter alertCount;
+    private final EventCounter criticalCount;
+    private final EventCounter errorCount;
+    private final EventCounter warnCount;
+    private final EventCounter infoCount;
+    private final EventCounter debugCount;
+    private final EventCounter defaultCount;
 
     public AzureMetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
         // emergency level is not in use
 
-        // TODO doe it make sense to use these levels when they are not supported by the log accumulation tool?
-        alertCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "alert")
-                .description("Number of alert severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        alertCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "alert",
+                "Number of alert severity events that made it to the logs");
 
-        criticalCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "critical")
-                .description("Number of critical severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        criticalCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "critical",
+                "Number of critical severity events that made it to the logs");
 
-        errorCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "error")
-                .description("Number of error severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        errorCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "error",
+                "Number of error severity events that made it to the logs");
 
-        warnCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "warning")
-                .description("Number of warn severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        warnCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "warning",
+                "Number of warn severity events that made it to the logs");
 
-        infoCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "info")
-                .description("Number of info severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        infoCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "info",
+                "Number of info severity events that made it to the logs");
 
-        debugCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "debug")
-                .description("Number of debug severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        debugCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "debug",
+                "Number of debug severity events that made it to the logs");
 
-        defaultCounter = Counter.builder("logback.azure.events")
-                .tags(tags).tags("severity", "default")
-                .description("Number of default severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        defaultCount = COUNTER_FACTORY.register("logback.azure.events", registry, tags,
+                "severity", "default",
+                "Number of default severity events that made it to the logs");
     }
 
     @Override
@@ -94,24 +82,24 @@ public class AzureMetricsTurboFilter extends TurboFilter implements LoggingEvent
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorCounter.increment();
+                        errorCount.accept(1L);
                     }
                 } else {
-                    errorCounter.increment();
+                    errorCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -128,24 +116,24 @@ public class AzureMetricsTurboFilter extends TurboFilter implements LoggingEvent
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorCounter.increment();
+                        errorCount.accept(1L);
                     }
                 } else {
-                    errorCounter.increment();
+                    errorCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -156,34 +144,35 @@ public class AzureMetricsTurboFilter extends TurboFilter implements LoggingEvent
     protected void increment(DevOpsLevel severity) {
         switch (severity) {
             case ERROR_WAKE_ME_UP_RIGHT_NOW: {
-                alertCounter.increment();
+                alertCount.accept(1L);
                 break;
             }
             case ERROR_INTERRUPT_MY_DINNER: {
-                criticalCounter.increment();
+                criticalCount.accept(1L);
                 break;
             }
             case WARN: {
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             }
             case INFO: {
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             }
             case DEBUG: {
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             }
             case TRACE: {
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             }
             case ERROR_TELL_ME_TOMORROW:
             default: {
-                errorCounter.increment();
+                errorCount.accept(1L);
                 break;
             }
         }
     }
 }
+

--- a/azure/micrometer-azure/src/test/java/no/entur/logging/cloud/azure/micrometer/AzureLogbackMetricsTest.java
+++ b/azure/micrometer-azure/src/test/java/no/entur/logging/cloud/azure/micrometer/AzureLogbackMetricsTest.java
@@ -1,22 +1,23 @@
 package no.entur.logging.cloud.azure.micrometer;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AzureLogbackMetricsTest {
 
 	private static final DevOpsLogger log = DevOpsLoggerFactory.getLogger(AzureLogbackMetricsTest.class);
-	
+
 	@Test
 	public void givenGlobalRegistry_whenLogging_thenCounted() {
 		SimpleMeterRegistry oneSimpleMeter = new SimpleMeterRegistry();
@@ -25,7 +26,7 @@ public class AzureLogbackMetricsTest {
 	    AzureLogbackMetrics m = new AzureLogbackMetrics();
 
 	    m.bindTo(oneSimpleMeter);
-	    
+
 	    log.errorTellMeTomorrow("Error statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
@@ -33,18 +34,17 @@ public class AzureLogbackMetricsTest {
 	    log.errorInterruptMyDinner("Critical statement");
 	    log.errorInterruptMyDinner("Critical statement");
 
-	    Collection<Counter> counters = oneSimpleMeter.find("logback.azure.events").counters();
+	    assertThat(getCount(oneSimpleMeter, "logback.azure.events", "severity", "error")).isEqualTo(1.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.azure.events", "severity", "alert")).isEqualTo(2.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.azure.events", "severity", "critical")).isEqualTo(3.0);
+	}
 
-	    Optional<Counter> error = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("error")).findAny();
-	    assertTrue(error.isPresent());
-	    assertThat(error.get().count()).isEqualTo(1.0);
-	    
-	    Optional<Counter> alert = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("alert")).findAny();
-	    assertTrue(alert.isPresent());
-	    assertThat(alert.get().count()).isEqualTo(2.0);
-
-	    Optional<Counter> critical = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("critical")).findAny();
-	    assertTrue(critical.isPresent());
-	    assertThat(critical.get().count()).isEqualTo(3.0);
+	private double getCount(SimpleMeterRegistry registry, String metricName, String tagKey, String tagValue) {
+		Optional<Meter> meter = registry.find(metricName).tag(tagKey, tagValue).meters().stream().findAny();
+		if (meter.isEmpty()) return 0.0;
+		return StreamSupport.stream(meter.get().measure().spliterator(), false)
+				.filter(ms -> ms.getStatistic() == Statistic.COUNT)
+				.mapToDouble(Measurement::getValue)
+				.sum();
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 // Define version variables at root level so they're available everywhere
 ext {
-    springBootVersion = '4.0.6' // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/
+    springBootVersion = '4.0.7' // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/
     // The following versions are managed by Spring Boot BOM (no need to define here):
     // junitJupiterVersion, mockitoVersion, slf4jVersion, logbackVersion, 
     // jacksonVersion, jacksonDatabindVersion, micrometerVersion, janinoVersion,

--- a/examples/azure-grpc-spring-example/build.gradle
+++ b/examples/azure-grpc-spring-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/azure-web-example/build.gradle
+++ b/examples/azure-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/examples/gcp-async-web-example/build.gradle
+++ b/examples/gcp-async-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/examples/gcp-grpc-spring-example/build.gradle
+++ b/examples/gcp-grpc-spring-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/gcp-grpc-spring-without-test-artifacts-example/build.gradle
+++ b/examples/gcp-grpc-spring-without-test-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/gcp-web-apache-client-example/build.gradle
+++ b/examples/gcp-web-apache-client-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/examples/gcp-web-example/build.gradle
+++ b/examples/gcp-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/examples/gcp-web-without-test-artifacts-example/build.gradle
+++ b/examples/gcp-web-without-test-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/examples/gcp-web-without-test-or-ondemand-artifacts-example/build.gradle
+++ b/examples/gcp-web-without-test-or-ondemand-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.0.7'
 }
 
 test {

--- a/gcp/micrometer-gcp/src/main/java/no/entur/logging/cloud/gcp/micrometer/StackdriverMetricsTurboFilter.java
+++ b/gcp/micrometer-gcp/src/main/java/no/entur/logging/cloud/gcp/micrometer/StackdriverMetricsTurboFilter.java
@@ -5,11 +5,12 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import no.entur.logging.cloud.api.DevOpsLevel;
 import no.entur.logging.cloud.api.DevOpsMarker;
+import no.entur.logging.cloud.micrometer.counter.EventCounter;
+import no.entur.logging.cloud.micrometer.counter.EventCounterFactory;
 import no.entur.logging.cloud.micrometer.LoggingEventMetrics;
 import org.slf4j.Marker;
 
@@ -17,58 +18,46 @@ import java.util.List;
 
 public class StackdriverMetricsTurboFilter extends TurboFilter implements LoggingEventMetrics {
 
-    protected final Counter alertCounter;
-    protected final Counter criticalCounter;
-    protected final Counter errorCounter;
-    protected final Counter warnCounter;
-    protected final Counter infoCounter;
-    protected final Counter debugCounter;
-    protected final Counter defaultCounter;
+    private static final EventCounterFactory COUNTER_FACTORY = EventCounterFactory.forCurrentMicrometerVersion();
+
+    protected final EventCounter alertCount;
+    protected final EventCounter criticalCount;
+    protected final EventCounter errorCount;
+    protected final EventCounter warnCount;
+    protected final EventCounter infoCount;
+    protected final EventCounter debugCount;
+    protected final EventCounter defaultCount;
 
     public StackdriverMetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
         // emergency level is not in use
 
-        alertCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "alert")
-                .description("Number of alert severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        alertCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "alert",
+                "Number of alert severity events that made it to the logs");
 
-        criticalCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "critical")
-                .description("Number of critical severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        criticalCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "critical",
+                "Number of critical severity events that made it to the logs");
 
-        errorCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "error")
-                .description("Number of error severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        errorCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "error",
+                "Number of error severity events that made it to the logs");
 
-        warnCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "warning")
-                .description("Number of warn severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        warnCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "warning",
+                "Number of warn severity events that made it to the logs");
 
-        infoCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "info")
-                .description("Number of info severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        infoCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "info",
+                "Number of info severity events that made it to the logs");
 
-        debugCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "debug")
-                .description("Number of debug severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        debugCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "debug",
+                "Number of debug severity events that made it to the logs");
 
-        defaultCounter = Counter.builder("logback.gcp.events")
-                .tags(tags).tags("severity", "default")
-                .description("Number of default severity events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        defaultCount = COUNTER_FACTORY.register("logback.gcp.events", registry, tags,
+                "severity", "default",
+                "Number of default severity events that made it to the logs");
     }
 
     @Override
@@ -92,24 +81,24 @@ public class StackdriverMetricsTurboFilter extends TurboFilter implements Loggin
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorCounter.increment();
+                        errorCount.accept(1L);
                     }
                 } else {
-                    errorCounter.increment();
+                    errorCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -128,24 +117,24 @@ public class StackdriverMetricsTurboFilter extends TurboFilter implements Loggin
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorCounter.increment();
+                        errorCount.accept(1L);
                     }
                 } else {
-                    errorCounter.increment();
+                    errorCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -156,32 +145,32 @@ public class StackdriverMetricsTurboFilter extends TurboFilter implements Loggin
     protected void increment(DevOpsLevel severity) {
         switch (severity) {
             case ERROR_WAKE_ME_UP_RIGHT_NOW: {
-                alertCounter.increment();
+                alertCount.accept(1L);
                 break;
             }
             case ERROR_INTERRUPT_MY_DINNER: {
-                criticalCounter.increment();
+                criticalCount.accept(1L);
                 break;
             }
             case WARN: {
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             }
             case INFO: {
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             }
             case DEBUG: {
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             }
             case TRACE: {
-                defaultCounter.increment();
+                defaultCount.accept(1L);
                 break;
             }
             case ERROR_TELL_ME_TOMORROW:
             default: {
-                errorCounter.increment();
+                errorCount.accept(1L);
                 break;
             }
         }
@@ -190,34 +179,35 @@ public class StackdriverMetricsTurboFilter extends TurboFilter implements Loggin
     public void increment(DevOpsLevel severity, int amount) {
         switch (severity) {
             case ERROR_WAKE_ME_UP_RIGHT_NOW: {
-                alertCounter.increment(amount);
+                alertCount.accept(amount);
                 break;
             }
             case ERROR_INTERRUPT_MY_DINNER: {
-                criticalCounter.increment(amount);
+                criticalCount.accept(amount);
                 break;
             }
             case WARN: {
-                warnCounter.increment(amount);
+                warnCount.accept(amount);
                 break;
             }
             case INFO: {
-                infoCounter.increment(amount);
+                infoCount.accept(amount);
                 break;
             }
             case DEBUG: {
-                debugCounter.increment(amount);
+                debugCount.accept(amount);
                 break;
             }
             case TRACE: {
-                defaultCounter.increment(amount);
+                defaultCount.accept(amount);
                 break;
             }
             case ERROR_TELL_ME_TOMORROW:
             default: {
-                errorCounter.increment(amount);
+                errorCount.accept(amount);
                 break;
             }
         }
     }
 }
+

--- a/gcp/micrometer-gcp/src/test/java/no/entur/logging/cloud/gcp/micrometer/StackdriverLogbackMetricsTest.java
+++ b/gcp/micrometer-gcp/src/test/java/no/entur/logging/cloud/gcp/micrometer/StackdriverLogbackMetricsTest.java
@@ -1,22 +1,23 @@
 package no.entur.logging.cloud.gcp.micrometer;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StackdriverLogbackMetricsTest {
 
 	private static DevOpsLogger log = DevOpsLoggerFactory.getLogger(StackdriverLogbackMetricsTest.class);
-	
+
 	@Test
 	public void givenGlobalRegistry_whenLogging_thenCounted() {
 		SimpleMeterRegistry oneSimpleMeter = new SimpleMeterRegistry();
@@ -25,7 +26,7 @@ public class StackdriverLogbackMetricsTest {
 	    StackdriverLogbackMetrics m = new StackdriverLogbackMetrics();
 
 	    m.bindTo(oneSimpleMeter);
-	    
+
 	    log.errorTellMeTomorrow("Error statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
@@ -33,18 +34,17 @@ public class StackdriverLogbackMetricsTest {
 	    log.errorInterruptMyDinner("Critical statement");
 	    log.errorInterruptMyDinner("Critical statement");
 
-	    Collection<Counter> counters = oneSimpleMeter.find("logback.gcp.events").counters();
+	    assertThat(getCount(oneSimpleMeter, "logback.gcp.events", "severity", "error")).isEqualTo(1.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.gcp.events", "severity", "alert")).isEqualTo(2.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.gcp.events", "severity", "critical")).isEqualTo(3.0);
+	}
 
-	    Optional<Counter> error = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("error")).findAny();
-	    assertTrue(error.isPresent());
-	    assertThat(error.get().count()).isEqualTo(1.0);
-	    
-	    Optional<Counter> alert = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("alert")).findAny();
-	    assertTrue(alert.isPresent());
-	    assertThat(alert.get().count()).isEqualTo(2.0);
-
-	    Optional<Counter> critical = counters.stream().filter(counter -> counter.getId().getTag("severity").equals("critical")).findAny();
-	    assertTrue(critical.isPresent());
-	    assertThat(critical.get().count()).isEqualTo(3.0);
+	private double getCount(SimpleMeterRegistry registry, String metricName, String tagKey, String tagValue) {
+		Optional<Meter> meter = registry.find(metricName).tag(tagKey, tagValue).meters().stream().findAny();
+		if (meter.isEmpty()) return 0.0;
+		return StreamSupport.stream(meter.get().measure().spliterator(), false)
+				.filter(ms -> ms.getStatistic() == Statistic.COUNT)
+				.mapToDouble(Measurement::getValue)
+				.sum();
 	}
 }

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/DevOpsMetricsTurboFilter.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/DevOpsMetricsTurboFilter.java
@@ -5,76 +5,63 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import no.entur.logging.cloud.api.DevOpsLevel;
 import no.entur.logging.cloud.api.DevOpsMarker;
+import no.entur.logging.cloud.micrometer.counter.EventCounter;
+import no.entur.logging.cloud.micrometer.counter.EventCounterFactory;
 import org.slf4j.Marker;
 
 import java.util.List;
 
 public class DevOpsMetricsTurboFilter extends TurboFilter implements LoggingEventMetrics {
 
-    protected final Counter errorWakeMeUpRightNowCounter;
-    protected final Counter errorInterruptMyDinnerCounter;
-    protected final Counter errorTellMeTomorrowCounter;
+    private static final EventCounterFactory COUNTER_FACTORY = EventCounterFactory.forCurrentMicrometerVersion();
 
-    protected final Counter errorCounter; // alias for all errors / backwards compatibility
+    protected final EventCounter errorWakeMeUpRightNowCount;
+    protected final EventCounter errorInterruptMyDinnerCount;
+    protected final EventCounter errorTellMeTomorrowCount;
 
-    protected final Counter warnCounter;
-    protected final Counter infoCounter;
-    protected final Counter debugCounter;
-    protected final Counter traceCounter;
+    protected final EventCounter errorCount; // alias for all errors / backwards compatibility
+
+    protected final EventCounter warnCount;
+    protected final EventCounter infoCount;
+    protected final EventCounter debugCount;
+    protected final EventCounter traceCount;
 
     public DevOpsMetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
-        errorWakeMeUpRightNowCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "errorWakeMeUpRightNow")
-                .description("Number of error 'Wake Me Up Right Now' level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        errorWakeMeUpRightNowCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "errorWakeMeUpRightNow",
+                "Number of error 'Wake Me Up Right Now' level events that made it to the logs");
 
-        errorInterruptMyDinnerCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "errorInterruptMyDinner")
-                .description("Number of error 'Interrupt My Dinner' level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        errorInterruptMyDinnerCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "errorInterruptMyDinner",
+                "Number of error 'Interrupt My Dinner' level events that made it to the logs");
 
-        errorTellMeTomorrowCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "errorTellMeTomorrow")
-                .description("Number of error 'Tell Me Tomorrow' level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        errorTellMeTomorrowCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "errorTellMeTomorrow",
+                "Number of error 'Tell Me Tomorrow' level events that made it to the logs");
 
-        errorCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "error")
-                .description("Number of all error level events that made it to the logs (errorTellMeTomorrow + errorInterruptMyDinner + errorWakeMeUpRightNow)")
-                .baseUnit("events")
-                .register(registry);
+        errorCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "error",
+                "Number of all error level events that made it to the logs (errorTellMeTomorrow + errorInterruptMyDinner + errorWakeMeUpRightNow)");
 
-        warnCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "warn")
-                .description("Number of warn level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        warnCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "warn",
+                "Number of warn level events that made it to the logs");
 
-        infoCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "info")
-                .description("Number of info level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        infoCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "info",
+                "Number of info level events that made it to the logs");
 
-        debugCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "debug")
-                .description("Number of debug level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        debugCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "debug",
+                "Number of debug level events that made it to the logs");
 
-        traceCounter = Counter.builder("logback.events")
-                .tags(tags).tags("level", "trace")
-                .description("Number of trace level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        traceCount = COUNTER_FACTORY.register("logback.events", registry, tags,
+                "level", "trace",
+                "Number of trace level events that made it to the logs");
     }
 
     @Override
@@ -91,7 +78,7 @@ public class DevOpsMetricsTurboFilter extends TurboFilter implements LoggingEven
         Level level = event.getLevel();
         switch (level.toInt()) {
             case Level.ERROR_INT:
-                errorCounter.increment();
+                errorCount.accept(1L);
 
                 List<Marker> markerList = event.getMarkerList();
                 if(markerList != null && !markerList.isEmpty()) {
@@ -99,24 +86,24 @@ public class DevOpsMetricsTurboFilter extends TurboFilter implements LoggingEven
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorTellMeTomorrowCounter.increment();
+                        errorTellMeTomorrowCount.accept(1L);
                     }
                 } else {
-                    errorTellMeTomorrowCounter.increment();
+                    errorTellMeTomorrowCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                traceCounter.increment();
+                traceCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -127,31 +114,31 @@ public class DevOpsMetricsTurboFilter extends TurboFilter implements LoggingEven
     public void increment(Marker marker, Level level) {
         switch (level.toInt()) {
             case Level.ERROR_INT:
-                errorCounter.increment();
+                errorCount.accept(1L);
 
                 if (marker != null) {
                     DevOpsLevel severity = DevOpsMarker.searchSeverityMarker(marker);
                     if (severity != null) {
                         increment(severity);
                     } else {
-                        errorTellMeTomorrowCounter.increment();
+                        errorTellMeTomorrowCount.accept(1L);
                     }
                 } else {
-                    errorTellMeTomorrowCounter.increment();
+                    errorTellMeTomorrowCount.accept(1L);
                 }
 
                 break;
             case Level.WARN_INT:
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             case Level.INFO_INT:
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             case Level.DEBUG_INT:
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             case Level.TRACE_INT:
-                traceCounter.increment();
+                traceCount.accept(1L);
                 break;
             default: {
                 // do nothing
@@ -162,72 +149,71 @@ public class DevOpsMetricsTurboFilter extends TurboFilter implements LoggingEven
     protected void increment(DevOpsLevel severity) {
         switch (severity) {
             case ERROR_WAKE_ME_UP_RIGHT_NOW: {
-                errorWakeMeUpRightNowCounter.increment();
+                errorWakeMeUpRightNowCount.accept(1L);
                 break;
             }
             case ERROR_INTERRUPT_MY_DINNER: {
-                errorInterruptMyDinnerCounter.increment();
+                errorInterruptMyDinnerCount.accept(1L);
                 break;
             }
             case ERROR_TELL_ME_TOMORROW: {
-                errorTellMeTomorrowCounter.increment();
+                errorTellMeTomorrowCount.accept(1L);
                 break;
             }
             case WARN: {
-                warnCounter.increment();
+                warnCount.accept(1L);
                 break;
             }
             case INFO: {
-                infoCounter.increment();
+                infoCount.accept(1L);
                 break;
             }
             case DEBUG: {
-                debugCounter.increment();
+                debugCount.accept(1L);
                 break;
             }
             case TRACE: {
-                traceCounter.increment();
+                traceCount.accept(1L);
                 break;
             }
             default: {
-                errorTellMeTomorrowCounter.increment();
+                errorTellMeTomorrowCount.accept(1L);
             }
         }
     }
 
-
     public void increment(DevOpsLevel severity, int amount) {
         switch (severity) {
             case ERROR_WAKE_ME_UP_RIGHT_NOW: {
-                errorWakeMeUpRightNowCounter.increment(amount);
+                errorWakeMeUpRightNowCount.accept(amount);
                 break;
             }
             case ERROR_INTERRUPT_MY_DINNER: {
-                errorInterruptMyDinnerCounter.increment(amount);
+                errorInterruptMyDinnerCount.accept(amount);
                 break;
             }
             case ERROR_TELL_ME_TOMORROW: {
-                errorTellMeTomorrowCounter.increment(amount);
+                errorTellMeTomorrowCount.accept(amount);
                 break;
             }
             case WARN: {
-                warnCounter.increment(amount);
+                warnCount.accept(amount);
                 break;
             }
             case INFO: {
-                infoCounter.increment(amount);
+                infoCount.accept(amount);
                 break;
             }
             case DEBUG: {
-                debugCounter.increment(amount);
+                debugCount.accept(amount);
                 break;
             }
             case TRACE: {
-                traceCounter.increment(amount);
+                traceCount.accept(amount);
                 break;
             }
             default: {
-                errorTellMeTomorrowCounter.increment(amount);
+                errorTellMeTomorrowCount.accept(amount);
             }
         }
     }

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/EventCounter.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/EventCounter.java
@@ -1,0 +1,13 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import java.util.function.LongConsumer;
+
+/**
+ * Abstraction over a Micrometer counter that works with both
+ * {@code FunctionCounter} (Spring Boot 4.1+ / Micrometer 1.17+) and
+ * {@code Counter} (Spring Boot 4.0.x).
+ *
+ * <p>Call {@link #accept(long)} to increment the counter by {@code n}.
+ */
+public interface EventCounter extends LongConsumer {
+}

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/EventCounterFactory.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/EventCounterFactory.java
@@ -1,0 +1,36 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+/**
+ * Factory that creates and registers an {@link EventCounter}.
+ *
+ * <p>Use {@link #forCurrentMicrometerVersion()} to obtain the appropriate factory
+ * for the runtime Micrometer version. Micrometer 1.17+ registers {@code logback.events}
+ * as a {@code FunctionCounter}; earlier versions use a cumulative {@code Counter}.
+ */
+public interface EventCounterFactory {
+
+    EventCounter register(String metricName, MeterRegistry registry,
+                               Iterable<Tag> tags, String tagKey, String tagValue,
+                               String description);
+
+    static EventCounterFactory forCurrentMicrometerVersion() {
+        Package pkg = Counter.class.getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
+        if (version != null) {
+            try {
+                String[] parts = version.split("\\.");
+                int major = Integer.parseInt(parts[0]);
+                int minor = Integer.parseInt(parts[1]);
+                if (major < 1 || (major == 1 && minor < 17)) {
+                    return new LegacyEventCounterFactory();
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return new FunctionEventCounterFactory();
+    }
+}

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/FunctionEventCounter.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/FunctionEventCounter.java
@@ -1,0 +1,17 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import java.util.concurrent.atomic.LongAdder;
+
+final class FunctionEventCounter implements EventCounter {
+
+    private final LongAdder adder;
+
+    FunctionEventCounter(LongAdder adder) {
+        this.adder = adder;
+    }
+
+    @Override
+    public void accept(long n) {
+        adder.add(n);
+    }
+}

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/FunctionEventCounterFactory.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/FunctionEventCounterFactory.java
@@ -1,0 +1,23 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public final class FunctionEventCounterFactory implements EventCounterFactory {
+
+    @Override
+    public EventCounter register(String metricName, MeterRegistry registry,
+                                      Iterable<Tag> tags, String tagKey, String tagValue,
+                                      String description) {
+        LongAdder adder = new LongAdder();
+        FunctionCounter.builder(metricName, adder, LongAdder::doubleValue)
+                .tags(tags).tags(tagKey, tagValue)
+                .description(description)
+                .baseUnit("events")
+                .register(registry);
+        return new FunctionEventCounter(adder);
+    }
+}

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/LegacyEventCounter.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/LegacyEventCounter.java
@@ -1,0 +1,28 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * {@link EventCounter} implementation backed by a Micrometer {@link Counter} (cumulative counter).
+ *
+ * <p>Used on Spring Boot 4.0.x, which ships Micrometer &lt; 1.17. In those versions,
+ * {@code MetricsTurboFilter} registers {@code logback.events} as a {@code Counter}, so all
+ * meters on the same metric name must use the same type to avoid an
+ * {@code IllegalArgumentException} at registration time.
+ *
+ * @see FunctionEventCounter
+ * @see LegacyEventCounterFactory
+ */
+final class LegacyEventCounter implements EventCounter {
+
+    private final Counter counter;
+
+    LegacyEventCounter(Counter counter) {
+        this.counter = counter;
+    }
+
+    @Override
+    public void accept(long n) {
+        counter.increment((double) n);
+    }
+}

--- a/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/LegacyEventCounterFactory.java
+++ b/micrometer/src/main/java/no/entur/logging/cloud/micrometer/counter/LegacyEventCounterFactory.java
@@ -1,0 +1,30 @@
+package no.entur.logging.cloud.micrometer.counter;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+/**
+ * {@link EventCounterFactory} that registers a Micrometer {@link Counter} (cumulative counter).
+ *
+ * <p>Used on Spring Boot 4.0.x, which ships Micrometer &lt; 1.17. In those versions,
+ * {@code MetricsTurboFilter} registers {@code logback.events} as a {@code Counter}, so all
+ * meters on the same metric name must use the same type to avoid an
+ * {@code IllegalArgumentException} at registration time.
+ *
+ * @see FunctionEventCounterFactory
+ */
+public final class LegacyEventCounterFactory implements EventCounterFactory {
+
+    @Override
+    public EventCounter register(String metricName, MeterRegistry registry,
+                                      Iterable<Tag> tags, String tagKey, String tagValue,
+                                      String description) {
+        Counter counter = Counter.builder(metricName)
+                .tags(tags).tags(tagKey, tagValue)
+                .description(description)
+                .baseUnit("events")
+                .register(registry);
+        return new LegacyEventCounter(counter);
+    }
+}

--- a/micrometer/src/test/java/no/entur/logging/cloud/micrometer/DevOpsLogbackMetricsTest.java
+++ b/micrometer/src/test/java/no/entur/logging/cloud/micrometer/DevOpsLogbackMetricsTest.java
@@ -1,22 +1,23 @@
 package no.entur.logging.cloud.micrometer;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import no.entur.logging.cloud.api.DevOpsLogger;
 import no.entur.logging.cloud.api.DevOpsLoggerFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DevOpsLogbackMetricsTest {
 
 	private static DevOpsLogger log = DevOpsLoggerFactory.getLogger(DevOpsLogbackMetricsTest.class);
-	
+
 	@Test
 	public void givenGlobalRegistry_whenLogging_thenCounted() {
 		SimpleMeterRegistry oneSimpleMeter = new SimpleMeterRegistry();
@@ -25,7 +26,7 @@ public class DevOpsLogbackMetricsTest {
 		DevOpsLogbackMetrics m = new DevOpsLogbackMetrics();
 
 	    m.bindTo(oneSimpleMeter);
-	    
+
 	    log.errorTellMeTomorrow("Error statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
 	    log.errorWakeMeUpRightNow("Alert statement");
@@ -33,18 +34,17 @@ public class DevOpsLogbackMetricsTest {
 	    log.errorInterruptMyDinner("Critical statement");
 	    log.errorInterruptMyDinner("Critical statement");
 
-	    Collection<Counter> counters = oneSimpleMeter.find("logback.events").counters();
+	    assertThat(getCount(oneSimpleMeter, "logback.events", "level", "errorTellMeTomorrow")).isEqualTo(1.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.events", "level", "errorWakeMeUpRightNow")).isEqualTo(2.0);
+	    assertThat(getCount(oneSimpleMeter, "logback.events", "level", "errorInterruptMyDinner")).isEqualTo(3.0);
+	}
 
-	    Optional<Counter> error = counters.stream().filter(counter -> counter.getId().getTag("level").equals("errorTellMeTomorrow")).findAny();
-	    assertTrue(error.isPresent());
-	    assertThat(error.get().count()).isEqualTo(1.0);
-	    
-	    Optional<Counter> alert = counters.stream().filter(counter -> counter.getId().getTag("level").equals("errorWakeMeUpRightNow")).findAny();
-	    assertTrue(alert.isPresent());
-	    assertThat(alert.get().count()).isEqualTo(2.0);
-
-	    Optional<Counter> critical = counters.stream().filter(counter -> counter.getId().getTag("level").equals("errorInterruptMyDinner")).findAny();
-	    assertTrue(critical.isPresent());
-	    assertThat(critical.get().count()).isEqualTo(3.0);
+	private double getCount(SimpleMeterRegistry registry, String metricName, String tagKey, String tagValue) {
+		Optional<Meter> meter = registry.find(metricName).tag(tagKey, tagValue).meters().stream().findAny();
+		if (meter.isEmpty()) return 0.0;
+		return StreamSupport.stream(meter.get().measure().spliterator(), false)
+				.filter(ms -> ms.getStatistic() == Statistic.COUNT)
+				.mapToDouble(Measurement::getValue)
+				.sum();
 	}
 }

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/build.gradle
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/build.gradle
@@ -1,5 +1,6 @@
 
 dependencies {
+    api project(':micrometer')
     api("io.micrometer:micrometer-core")
     api("org.springframework.boot:spring-boot-autoconfigure")
 

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/stderr/micrometer/StderrMicrometerAutoConfiguration.java
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/stderr/micrometer/StderrMicrometerAutoConfiguration.java
@@ -1,12 +1,16 @@
 package no.entur.logging.cloud.spring.stderr.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import no.entur.logging.cloud.micrometer.counter.EventCounter;
+import no.entur.logging.cloud.micrometer.counter.EventCounterFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+
+import java.util.Collections;
 
 /**
  * Spring Boot auto-configuration that intercepts {@code System.err} output and increments
@@ -15,11 +19,14 @@ import org.springframework.context.annotation.Bean;
  * <p>Activated by default when a {@link MeterRegistry} bean is present; can be disabled by
  * setting {@code entur.logging.stderr.micrometer.enabled=false}.
  */
-@AutoConfiguration(afterName = {
-        "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration",
-        "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
-        "org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration"
-})
+@AutoConfiguration(
+        afterName = {
+                "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration",
+                "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
+                "org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration"
+        },
+        beforeName = "org.springframework.boot.micrometer.metrics.autoconfigure.logging.logback.LogbackMetricsAutoConfiguration"
+)
 @ConditionalOnProperty(name = "entur.logging.stderr.micrometer.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(StderrMicrometerProperties.class)
 public class StderrMicrometerAutoConfiguration {
@@ -28,8 +35,19 @@ public class StderrMicrometerAutoConfiguration {
     @ConditionalOnBean(MeterRegistry.class)
     @ConditionalOnMissingBean(SystemErrMicrometerPrintStream.class)
     public SystemErrMicrometerPrintStream systemErrMicrometerPrintStream(MeterRegistry registry) {
-        SystemErrMicrometerPrintStream printStream = new SystemErrMicrometerPrintStream(registry, System.err);
+        EventCounterFactory factory = EventCounterFactory.forCurrentMicrometerVersion();
+
+        EventCounter errorCount = factory.register("logback.events", registry, Collections.emptyList(),
+                "level", "error",
+                "Number of all error level events that made it to the logs (errorTellMeTomorrow + errorInterruptMyDinner + errorWakeMeUpRightNow)");
+
+        EventCounter errorTellMeTomorrowCount = factory.register("logback.events", registry, Collections.emptyList(),
+                "level", "errorTellMeTomorrow",
+                "Number of error 'Tell Me Tomorrow' level events that made it to the logs");
+
+        SystemErrMicrometerPrintStream printStream = new SystemErrMicrometerPrintStream(System.err, errorCount, errorTellMeTomorrowCount);
         System.setErr(printStream);
         return printStream;
     }
+
 }

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/stderr/micrometer/SystemErrMicrometerPrintStream.java
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/src/main/java/no/entur/logging/cloud/spring/stderr/micrometer/SystemErrMicrometerPrintStream.java
@@ -1,7 +1,6 @@
 package no.entur.logging.cloud.spring.stderr.micrometer;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import no.entur.logging.cloud.micrometer.counter.EventCounter;
 import org.springframework.beans.factory.DisposableBean;
 
 import java.io.PrintStream;
@@ -27,32 +26,24 @@ import java.io.PrintStream;
 public class SystemErrMicrometerPrintStream extends PrintStream implements DisposableBean {
 
     private final PrintStream originalSystemErr;
-    private final Counter errorCounter;
-    private final Counter errorTellMeTomorrowCounter;
+    private final EventCounter errorCount;
+    private final EventCounter errorTellMeTomorrowCount;
 
-    public SystemErrMicrometerPrintStream(MeterRegistry registry, PrintStream originalSystemErr) {
+    public SystemErrMicrometerPrintStream(PrintStream originalSystemErr,
+                                          EventCounter errorCount,
+                                          EventCounter errorTellMeTomorrowCount) {
         super(originalSystemErr, true);
         this.originalSystemErr = originalSystemErr;
-
-        this.errorCounter = Counter.builder("logback.events")
-                .tags("level", "error")
-                .description("Number of all error level events that made it to the logs (errorTellMeTomorrow + errorInterruptMyDinner + errorWakeMeUpRightNow)")
-                .baseUnit("events")
-                .register(registry);
-
-        this.errorTellMeTomorrowCounter = Counter.builder("logback.events")
-                .tags("level", "errorTellMeTomorrow")
-                .description("Number of error 'Tell Me Tomorrow' level events that made it to the logs")
-                .baseUnit("events")
-                .register(registry);
+        this.errorCount = errorCount;
+        this.errorTellMeTomorrowCount = errorTellMeTomorrowCount;
     }
 
     @Override
     public void write(int b) {
         super.write(b);
         if (b == '\n') {
-            errorCounter.increment();
-            errorTellMeTomorrowCounter.increment();
+            errorCount.accept(1L);
+            errorTellMeTomorrowCount.accept(1L);
         }
     }
 
@@ -66,8 +57,8 @@ public class SystemErrMicrometerPrintStream extends PrintStream implements Dispo
             }
         }
         if (newlines > 0) {
-            errorCounter.increment(newlines);
-            errorTellMeTomorrowCounter.increment(newlines);
+            errorCount.accept(newlines);
+            errorTellMeTomorrowCount.accept(newlines);
         }
     }
 

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/StderrMicrometerEnabledTest.java
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/StderrMicrometerEnabledTest.java
@@ -1,15 +1,17 @@
 package no.entur.logging.cloud.spring.stderr.micrometer;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -200,10 +202,11 @@ public class StderrMicrometerEnabledTest {
     }
 
     private double getCount(String level) {
-        Collection<Counter> counters = meterRegistry.find("logback.events").counters();
-        Optional<Counter> counter = counters.stream()
-                .filter(c -> level.equals(c.getId().getTag("level")))
-                .findAny();
-        return counter.map(Counter::count).orElse(0.0);
+        Optional<Meter> meter = meterRegistry.find("logback.events").tag("level", level).meters().stream().findAny();
+        if (meter.isEmpty()) return 0.0;
+        return StreamSupport.stream(meter.get().measure().spliterator(), false)
+                .filter(ms -> ms.getStatistic() == Statistic.COUNT)
+                .mapToDouble(Measurement::getValue)
+                .sum();
     }
 }


### PR DESCRIPTION
Spring Boot 4.1 ships Micrometer 1.17 which changed `MetricsTurboFilter` from `Counter` to `FunctionCounter` + `LongAdder` for `logback.events` metrics. Mixing counter types on the same metric name throws `IllegalArgumentException`.

## Changes

Introduce `EventCounterFactory` that selects the correct Micrometer counter type at class-load time by reading `Counter.class.getPackage().getImplementationVersion()`:
- **Micrometer ≥ 1.17** → `FunctionEventCounterFactory` (LongAdder-backed `FunctionCounter`)
- **Micrometer < 1.17** → `LegacyEventCounterFactory` (cumulative `Counter`)

On the current Spring Boot 4.0.7 / Micrometer 1.16.x stack the behaviour is unchanged — `LegacyEventCounterFactory` is selected and counters are registered as before.

Also bumps Spring Boot from 4.0.6 → 4.0.7.

### New classes (`no.entur.logging.cloud.micrometer.counter`)
| Class | Role |
|---|---|
| `EventCounter` | Interface extending `LongConsumer` — `accept(long n)` to increment |
| `EventCounterFactory` | Factory interface + `forCurrentMicrometerVersion()` version check |
| `FunctionEventCounter` | Delegates to `LongAdder.add(n)` |
| `FunctionEventCounterFactory` | Registers `LongAdder` + `FunctionCounter` |
| `LegacyEventCounter` | Delegates to `Counter.increment((double) n)` |
| `LegacyEventCounterFactory` | Registers a cumulative `Counter` |

### Updated
- `DevOpsMetricsTurboFilter`, `StackdriverMetricsTurboFilter`, `AzureMetricsTurboFilter` — use `EventCounterFactory`
- `StderrMicrometerAutoConfiguration` — registers counters via factory
- `SystemErrMicrometerPrintStream` — takes `EventCounter` constructor args
- `stderr-micrometer-spring-boot-autoconfigure/build.gradle` — adds `:micrometer` dependency
- Test files — query meters via `Statistic.COUNT` (type-agnostic, works for both `Counter` and `FunctionCounter`)