### PR TITLE
Fix micrometer configuration for micrometer 1.17 compatibility

### DIFF
--- a/azure/spring-boot-autoconfigure-azure/build.gradle
+++ b/azure/spring-boot-autoconfigure-azure/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-logging")
     api("org.springframework.boot:spring-boot-starter-web")
     api ("org.springframework.boot:spring-boot-starter-security")
+    api("org.springframework.boot:spring-boot-micrometer-metrics")
 
     api ("org.codehaus.janino:janino")
 

--- a/azure/spring-boot-autoconfigure-azure/src/main/java/no/entur/logging/cloud/azure/spring/AzureLoggingAutoConfiguration.java
+++ b/azure/spring-boot-autoconfigure-azure/src/main/java/no/entur/logging/cloud/azure/spring/AzureLoggingAutoConfiguration.java
@@ -3,8 +3,6 @@ package no.entur.logging.cloud.azure.spring;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
-import no.entur.logging.cloud.api.DevOpsLogger;
-import no.entur.logging.cloud.api.DevOpsLoggerFactory;
 import no.entur.logging.cloud.appender.scope.LoggingScopeAsyncAppender;
 import no.entur.logging.cloud.azure.micrometer.AzureLogbackMetrics;
 import no.entur.logging.cloud.azure.spring.ondemand.AzureOndemandLoggingMeterBinder;
@@ -73,7 +71,7 @@ public class AzureLoggingAutoConfiguration {
         return new LogbackMetrics() {
             @Override
             public void bindTo(io.micrometer.core.instrument.MeterRegistry registry) {
-                // no-op: on-demand mode uses GcpOndemandLoggingMeterBinder for metrics
+                // no-op: on-demand mode uses AzureOndemandLoggingMeterBinder for metrics
             }
         };
     }

--- a/azure/spring-boot-autoconfigure-azure/src/main/java/no/entur/logging/cloud/azure/spring/AzureLoggingAutoConfiguration.java
+++ b/azure/spring-boot-autoconfigure-azure/src/main/java/no/entur/logging/cloud/azure/spring/AzureLoggingAutoConfiguration.java
@@ -11,7 +11,9 @@ import no.entur.logging.cloud.azure.spring.ondemand.AzureOndemandLoggingMeterBin
 import no.entur.logging.cloud.gcp.spring.ondemand.ConditionalOnDisabledOndemandLogging;
 import no.entur.logging.cloud.gcp.spring.ondemand.ConditionalOnEnabledOndemandLogging;
 import no.entur.logging.cloud.micrometer.DevOpsLogbackMetrics;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.micrometer.metrics.autoconfigure.logging.logback.LogbackMetricsAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,11 +27,10 @@ import org.springframework.context.annotation.Configuration;
  *
  */
 
+@AutoConfiguration(before = {LogbackMetricsAutoConfiguration.class})
 
 @Configuration
 public class AzureLoggingAutoConfiguration {
-
-    private static final DevOpsLogger LOGGER = DevOpsLoggerFactory.getLogger(AzureLoggingAutoConfiguration.class);
 
     @Bean
     @ConditionalOnClass(AzureLogbackMetrics.class)
@@ -57,5 +58,23 @@ public class AzureLoggingAutoConfiguration {
         appender.setMetrics(binder);
 
         return binder;
+    }
+
+    /**
+     * Suppresses Spring Boot's built-in {@code LogbackMetrics} when on-demand logging is enabled.
+     * In on-demand mode metrics are counted by {@code AzureOndemandLoggingMeterBinder} (appender-side)
+     * rather than by a turbo filter, so the built-in turbo-filter-based counting must be disabled.
+     */
+
+    @Bean
+    @ConditionalOnClass({DevOpsLogbackMetrics.class, AzureLogbackMetrics.class})
+    @ConditionalOnEnabledOndemandLogging
+    public LogbackMetrics azureOndemandLogbackMetricsSuppressor() {
+        return new LogbackMetrics() {
+            @Override
+            public void bindTo(io.micrometer.core.instrument.MeterRegistry registry) {
+                // no-op: on-demand mode uses GcpOndemandLoggingMeterBinder for metrics
+            }
+        };
     }
 }

--- a/gcp/spring-boot-autoconfigure-gcp/build.gradle
+++ b/gcp/spring-boot-autoconfigure-gcp/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-logging")
     api("org.springframework.boot:spring-boot-starter-web")
     api ("org.springframework.boot:spring-boot-starter-security")
+    api("org.springframework.boot:spring-boot-micrometer-metrics")
 
     api ("org.codehaus.janino:janino")
 

--- a/gcp/spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/gcp/spring/GcpLoggingAutoConfiguration.java
+++ b/gcp/spring-boot-autoconfigure-gcp/src/main/java/no/entur/logging/cloud/gcp/spring/GcpLoggingAutoConfiguration.java
@@ -9,7 +9,9 @@ import no.entur.logging.cloud.gcp.spring.ondemand.ConditionalOnDisabledOndemandL
 import no.entur.logging.cloud.gcp.spring.ondemand.ConditionalOnEnabledOndemandLogging;
 import no.entur.logging.cloud.gcp.spring.ondemand.GcpOndemandLoggingMeterBinder;
 import no.entur.logging.cloud.micrometer.DevOpsLogbackMetrics;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.micrometer.metrics.autoconfigure.logging.logback.LogbackMetricsAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
  * metrics within the appender so that only actually written log statements will count in our own metrics.
  *
  */
+@AutoConfiguration(before = {LogbackMetricsAutoConfiguration.class})
 
 @Configuration
 public class GcpLoggingAutoConfiguration {
@@ -52,6 +55,24 @@ public class GcpLoggingAutoConfiguration {
         appender.setMetrics(binder);
 
         return binder;
+    }
+
+    /**
+     * Suppresses Spring Boot's built-in {@code LogbackMetrics} when on-demand logging is enabled.
+     * In on-demand mode metrics are counted by {@code GcpOndemandLoggingMeterBinder} (appender-side)
+     * rather than by a turbo filter, so the built-in turbo-filter-based counting must be disabled.
+     */
+
+    @Bean
+    @ConditionalOnClass({DevOpsLogbackMetrics.class, StackdriverLogbackMetrics.class})
+    @ConditionalOnEnabledOndemandLogging
+    public LogbackMetrics gcpOndemandLogbackMetricsSuppressor() {
+        return new LogbackMetrics() {
+            @Override
+            public void bindTo(io.micrometer.core.instrument.MeterRegistry registry) {
+                // no-op: on-demand mode uses GcpOndemandLoggingMeterBinder for metrics
+            }
+        };
     }
 
 }

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/build.gradle
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}"
 
+    testImplementation project(":micrometer")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-actuator")
     testRuntimeOnly("ch.qos.logback:logback-classic")

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/TestConfiguration.java
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/TestConfiguration.java
@@ -1,0 +1,15 @@
+package no.entur.logging.cloud.spring.stderr.micrometer;
+
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestConfiguration {
+
+    @Bean
+    public LogbackMetrics logbackMetrics() {
+        return new no.entur.logging.cloud.micrometer.DevOpsLogbackMetrics();
+    }
+}

--- a/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/TestConfiguration.java
+++ b/stderr/stderr-micrometer-spring-boot-autoconfigure/src/test/java/no/entur/logging/cloud/spring/stderr/micrometer/TestConfiguration.java
@@ -1,7 +1,6 @@
 package no.entur.logging.cloud.spring.stderr.micrometer;
 
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 


### PR DESCRIPTION
The micrometer logback metric counter type changes in Micrometer 1.17 (Spring Boot 4.1). The current implementation registers some of the same counters; this now fails because the type must be the same.

Make sure the built-in `LogbackMetrics` metrics are not used, instead use our own subclass: 

 * Explicit autoconfiguration order.
 * Stop built-in metrics for on-demand logging

Tested in https://github.com/entur/cloud-logging/pull/398