### PR TITLE
Bump spring Boot 4.1.0 with gRPC 1.1.0

### DIFF
--- a/azure/request-response-spring-boot-starter-azure-grpc-spring/build.gradle
+++ b/azure/request-response-spring-boot-starter-azure-grpc-spring/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api ("org.springframework.boot:spring-boot-autoconfigure")
     api ("org.springframework.boot:spring-boot-starter-logging")
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/azure/spring-boot-starter-azure-grpc-spring/build.gradle
+++ b/azure/spring-boot-starter-azure-grpc-spring/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-autoconfigure")
     api("org.springframework.boot:spring-boot-starter-logging")
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     api "io.grpc:grpc-netty:${grpcNettyVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ ext {
     grpcVersion = '1.82.0'
     grpcCommonsVersion = '2.72.0'
     grpcProtobufVersion = '4.35.0'
-    // spring-grpc is now included in Spring Boot 4.1+ BOM (spring-boot-starter-grpc-server etc.)
 
     jsonAssertVersion = '0.8.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 // Define version variables at root level so they're available everywhere
 ext {
-    springBootVersion = '4.0.7' // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/
+    springBootVersion = '4.1.0' // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/
     // The following versions are managed by Spring Boot BOM (no need to define here):
     // junitJupiterVersion, mockitoVersion, slf4jVersion, logbackVersion, 
     // jacksonVersion, jacksonDatabindVersion, micrometerVersion, janinoVersion,
@@ -28,7 +28,7 @@ ext {
     grpcVersion = '1.82.0'
     grpcCommonsVersion = '2.72.0'
     grpcProtobufVersion = '4.35.0'
-    springGrpcVersion = '1.0.3'
+    // spring-grpc is now included in Spring Boot 4.1+ BOM (spring-boot-starter-grpc-server etc.)
 
     jsonAssertVersion = '0.8.0'
 }

--- a/examples/azure-grpc-spring-example/build.gradle
+++ b/examples/azure-grpc-spring-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/azure-web-example/build.gradle
+++ b/examples/azure-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/examples/gcp-async-web-example/build.gradle
+++ b/examples/gcp-async-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/examples/gcp-grpc-spring-example/build.gradle
+++ b/examples/gcp-grpc-spring-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/gcp-grpc-spring-without-test-artifacts-example/build.gradle
+++ b/examples/gcp-grpc-spring-without-test-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
     id "com.google.protobuf" version "0.10.0"
 }
 

--- a/examples/gcp-web-apache-client-example/build.gradle
+++ b/examples/gcp-web-apache-client-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/examples/gcp-web-example/build.gradle
+++ b/examples/gcp-web-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/examples/gcp-web-without-test-artifacts-example/build.gradle
+++ b/examples/gcp-web-without-test-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/examples/gcp-web-without-test-or-ondemand-artifacts-example/build.gradle
+++ b/examples/gcp-web-without-test-or-ondemand-artifacts-example/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '4.1.0'
 }
 
 test {

--- a/gcp/request-response-spring-boot-starter-gcp-grpc-spring-test/build.gradle
+++ b/gcp/request-response-spring-boot-starter-gcp-grpc-spring-test/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':gcp:request-response-spring-boot-starter-gcp-grpc-spring')
     api project(':request-response:request-response-spring-boot-autoconfigure-grpc-spring')
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     api ("org.entur.jackson:jackson-tools-syntax-highlight:${jacksonSyntaxHighlightVersion}")
     api ("org.entur.logback-logstash-syntax-highlighting-decorators:logback-logstash-syntax-highlighting-decorators:${logbackLogstashSyntaxHighlightingDecoratorsVersion}")

--- a/gcp/request-response-spring-boot-starter-gcp-grpc-spring/build.gradle
+++ b/gcp/request-response-spring-boot-starter-gcp-grpc-spring/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api ("org.springframework.boot:spring-boot-autoconfigure")
     api ("org.springframework.boot:spring-boot-starter-logging")
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/gcp/spring-boot-starter-gcp-grpc-spring/build.gradle
+++ b/gcp/spring-boot-starter-gcp-grpc-spring/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-autoconfigure")
     api("org.springframework.boot:spring-boot-starter-logging")
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     api "io.grpc:grpc-netty:${grpcNettyVersion}"
 

--- a/request-response/request-response-spring-boot-autoconfigure-grpc-spring/build.gradle
+++ b/request-response/request-response-spring-boot-autoconfigure-grpc-spring/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api ("org.springframework.boot:spring-boot-starter-logging")
     api ("org.springframework.security:spring-security-core")
 
-    api("org.springframework.grpc:spring-grpc-server-spring-boot-starter:${springGrpcVersion}")
+    api("org.springframework.boot:spring-boot-starter-grpc-server")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/request-response/request-response-spring-boot-autoconfigure-grpc-spring/src/main/java/no/entur/logging/cloud/spring/grpc/spring/RequestResponseExceptionHandlerGrpcSpringAutoConfiguration.java
+++ b/request-response/request-response-spring-boot-autoconfigure-grpc-spring/src/main/java/no/entur/logging/cloud/spring/grpc/spring/RequestResponseExceptionHandlerGrpcSpringAutoConfiguration.java
@@ -3,8 +3,9 @@ package no.entur.logging.cloud.spring.grpc.spring;
 import no.entur.logging.cloud.spring.rr.grpc.RequestResponseGrpcExceptionHandlerInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.grpc.server.autoconfigure.exception.GrpcExceptionHandlerAutoConfiguration;
+import org.springframework.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.grpc.server.exception.GrpcExceptionHandlerInterceptor;
@@ -18,13 +19,14 @@ import org.springframework.grpc.server.exception.GrpcExceptionHandlerInterceptor
  */
 
 @Configuration
-@AutoConfigureAfter(GrpcExceptionHandlerAutoConfiguration.class)
+@AutoConfigureAfter(GrpcServerAutoConfiguration.class)
 public class RequestResponseExceptionHandlerGrpcSpringAutoConfiguration {
 
     @Value("${entur.logging.request-response.grpc.server.exception-handler.interceptor-order:400}")
     private int exceptionInterceptorOrder;
 
     @Bean
+    @ConditionalOnBean(GrpcExceptionHandlerInterceptor.class)
     @ConditionalOnProperty(name = {"entur.logging.request-response.grpc.server.exception-handler.enabled"}, havingValue = "true", matchIfMissing = true)
     public RequestResponseGrpcExceptionHandlerInterceptor requestResponseGrpcExceptionHandlerInterceptor(GrpcExceptionHandlerInterceptor interceptor) {
         return new RequestResponseGrpcExceptionHandlerInterceptor(interceptor, exceptionInterceptorOrder);

--- a/request-response/request-response-spring-boot-autoconfigure-grpc-spring/src/main/java/no/entur/logging/cloud/spring/grpc/spring/RequestResponseGrpcSpringAutoConfiguration.java
+++ b/request-response/request-response-spring-boot-autoconfigure-grpc-spring/src/main/java/no/entur/logging/cloud/spring/grpc/spring/RequestResponseGrpcSpringAutoConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.grpc.server.autoconfigure.exception.GrpcExceptionHandlerAutoConfiguration;
+import org.springframework.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Configuration;
  */
 
 @Configuration
-@AutoConfigureBefore(GrpcExceptionHandlerAutoConfiguration.class)
+@AutoConfigureBefore(GrpcServerAutoConfiguration.class)
 public class RequestResponseGrpcSpringAutoConfiguration {
 
     @Value("${entur.logging.request-response.grpc.server.interceptor-order:300}")


### PR DESCRIPTION
https://github.com/spring-projects/spring-grpc/wiki/Spring-gRPC-1.1-Migration-Guide

Note: gRPC dependencies have changed. At least new minor version. 